### PR TITLE
Fix plugin resolution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "RepostInstagramApp"
 include(":app")


### PR DESCRIPTION
## Summary
- include Google repository so Android Gradle Plugin can be resolved

## Testing
- `gradle -q tasks --all`
- `gradle -q build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d3affcf883279cd67281374ed9e4