### PR TITLE
Set up AndroidX support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and Jetifier by default

## Testing
- `gradle app:dependencies --configuration debugRuntimeClasspath`
- `gradle help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6858dc178134832790c49abedca41998