### PR TITLE
Fix manifest export flag

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,9 @@
         <activity android:name=".DashboardActivity" />
         <activity android:name=".UserProfileActivity" />
         <activity android:name=".LoginActivity" />
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- specify `android:exported` on `MainActivity` since it has an intent filter

## Testing
- `gradle assembleDebug` *(fails: Gradle hang)*

------
https://chatgpt.com/codex/tasks/task_e_6858ddf3b31c8327a45c9e4dda43b8be