### PR TITLE
Fix Kotlin compile JDK mismatch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,15 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- align Java and Kotlin compile targets to 1.8

## Testing
- `gradle :app:assembleDebug --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e823106083278c87dd22faeb5fbd