### PR TITLE
Add auto-redirect from landing to login

### DIFF
--- a/app/src/main/java/com/example/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/example/repostapp/MainActivity.kt
@@ -2,12 +2,18 @@ package com.example.repostapp
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        // TODO: navigate to LoginActivity or Dashboard depending on user session
+        // After showing the landing page for 5 seconds, navigate to the login page
+        Handler(Looper.getMainLooper()).postDelayed({
+            startActivity(Intent(this, LoginActivity::class.java))
+            finish()
+        }, 5000)
     }
 }


### PR DESCRIPTION
## Summary
- use `Handler.postDelayed` to redirect landing page to login page after 5 seconds

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6858ed1045d48327a1e0475ba591c240