### PR TITLE
Update login API URL and error message

### DIFF
--- a/app/src/main/java/com/example/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/example/repostapp/LoginActivity.kt
@@ -44,7 +44,7 @@ class LoginActivity : AppCompatActivity() {
             }
             val body = json.toString().toRequestBody("application/json".toMediaType())
             val request = Request.Builder()
-                .url("http://103.182.52.127/api/auth/user-login")
+                .url("https://papiqo.com/api/auth/user-login")
                 .post(body)
                 .build()
 
@@ -73,7 +73,11 @@ class LoginActivity : AppCompatActivity() {
                 }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(this@LoginActivity, "Terjadi kesalahan", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        this@LoginActivity,
+                        "Gagal terhubung ke server",
+                        Toast.LENGTH_SHORT
+                    ).show()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- use `https://papiqo.com` API endpoint for login
- show a clearer toast if login request fails

## Testing
- `./gradlew assembleDebug` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6858f5bcfac88327a69137b202f1877b