### PR TITLE
Show user profile after login

### DIFF
--- a/app/src/main/java/com/example/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/example/repostapp/LoginActivity.kt
@@ -64,7 +64,18 @@ class LoginActivity : AppCompatActivity() {
 
                     withContext(Dispatchers.Main) {
                         if (success) {
-                            startActivity(Intent(this@LoginActivity, DashboardActivity::class.java))
+                            val data = try {
+                                val obj = JSONObject(responseBody ?: "{}")
+                                obj.optJSONObject("data")
+                            } catch (e: Exception) {
+                                null
+                            }
+                            val intent = Intent(this@LoginActivity, UserProfileActivity::class.java).apply {
+                                putExtra("nrp", data?.optString("nrp", nrp) ?: nrp)
+                                putExtra("name", data?.optString("name", ""))
+                                putExtra("phone", data?.optString("whatsapp", phone) ?: phone)
+                            }
+                            startActivity(intent)
                             finish()
                         } else {
                             Toast.makeText(this@LoginActivity, message, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
@@ -1,12 +1,19 @@
 package com.example.repostapp
 
 import android.os.Bundle
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 
 class UserProfileActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_profile)
-        // TODO: show user profile info
+        val nrp = intent.getStringExtra("nrp") ?: ""
+        val name = intent.getStringExtra("name") ?: ""
+        val phone = intent.getStringExtra("phone") ?: ""
+
+        findViewById<TextView>(R.id.text_nrp).text = "NRP: $nrp"
+        findViewById<TextView>(R.id.text_name).text = "Nama: $name"
+        findViewById<TextView>(R.id.text_phone).text = "Telepon: $phone"
     }
 }

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -1,11 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
+    android:padding="16dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <TextView
+        android:id="@+id/text_nrp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="User Profile Page" />
+        android:text="NRP:" />
+
+    <TextView
+        android:id="@+id/text_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nama:" />
+
+    <TextView
+        android:id="@+id/text_phone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Telepon:" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- parse login response data
- navigate to `UserProfileActivity` on login success
- display NRP, name and phone in profile layout

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb5bd76c8327a9d7a10cebac9071