### PR TITLE
Update profile data via Cicero_V2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ The project uses Gradle Kotlin DSL. To build the project you would typically run
 ```
 
 Additional implementation is required to integrate Instagram APIs and handle authentication.
+
+The app retrieves user profile information from the [Cicero_V2](https://github.com/cicero78M/Cicero_V2) backend API.
+After a successful login, the token and user ID returned by `/api/auth/user-login`
+are used to request `/api/users/{userId}` to display the profile screen.

--- a/app/src/main/java/com/example/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/example/repostapp/LoginActivity.kt
@@ -64,16 +64,17 @@ class LoginActivity : AppCompatActivity() {
 
                     withContext(Dispatchers.Main) {
                         if (success) {
-                            val data = try {
-                                val obj = JSONObject(responseBody ?: "{}")
-                                obj.optJSONObject("data")
+                            val obj = try {
+                                JSONObject(responseBody ?: "{}")
                             } catch (e: Exception) {
-                                null
+                                JSONObject()
                             }
+                            val token = obj.optString("token", "")
+                            val user = obj.optJSONObject("user")
+                            val userId = user?.optString("user_id", nrp) ?: nrp
                             val intent = Intent(this@LoginActivity, UserProfileActivity::class.java).apply {
-                                putExtra("nrp", data?.optString("nrp", nrp) ?: nrp)
-                                putExtra("name", data?.optString("name", ""))
-                                putExtra("phone", data?.optString("whatsapp", phone) ?: phone)
+                                putExtra("token", token)
+                                putExtra("userId", userId)
                             }
                             startActivity(intent)
                             finish()

--- a/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
@@ -2,18 +2,58 @@ package com.example.repostapp
 
 import android.os.Bundle
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
 
 class UserProfileActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_profile)
-        val nrp = intent.getStringExtra("nrp") ?: ""
-        val name = intent.getStringExtra("name") ?: ""
-        val phone = intent.getStringExtra("phone") ?: ""
+        val userId = intent.getStringExtra("userId") ?: ""
+        val token = intent.getStringExtra("token") ?: ""
+        if (userId.isNotBlank() && token.isNotBlank()) {
+            fetchProfile(userId, token)
+        }
+    }
 
-        findViewById<TextView>(R.id.text_nrp).text = "NRP: $nrp"
-        findViewById<TextView>(R.id.text_name).text = "Nama: $name"
-        findViewById<TextView>(R.id.text_phone).text = "Telepon: $phone"
+    private fun fetchProfile(userId: String, token: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val client = OkHttpClient()
+            val request = Request.Builder()
+                .url("https://papiqo.com/api/users/$userId")
+                .header("Authorization", "Bearer $token")
+                .build()
+            try {
+                client.newCall(request).execute().use { response ->
+                    val body = response.body?.string()
+                    withContext(Dispatchers.Main) {
+                        if (response.isSuccessful) {
+                            val data = try {
+                                val obj = JSONObject(body ?: "{}")
+                                obj.optJSONObject("data")
+                            } catch (_: Exception) {
+                                null
+                            }
+                            findViewById<TextView>(R.id.text_nrp).text = "NRP: " + (data?.optString("user_id") ?: userId)
+                            findViewById<TextView>(R.id.text_name).text = "Nama: " + (data?.optString("nama") ?: "")
+                            findViewById<TextView>(R.id.text_phone).text = "Telepon: " + (data?.optString("whatsapp") ?: "")
+                        } else {
+                            Toast.makeText(this@UserProfileActivity, "Gagal memuat profil", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(this@UserProfileActivity, "Gagal terhubung ke server", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- hook up profile screen with Cicero_V2 backend
- parse login response to pass token and user ID
- document backend usage in README

## Testing
- `gradlew` not present so build step skipped

------
https://chatgpt.com/codex/tasks/task_e_6858fd2d624c8327954de06131cea799