### PR TITLE
Implement dashboard bottom navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project contains a minimal Android application skeleton. The app includes s
 - `LoginActivity` for user authentication
 - `UserProfileActivity` to show user details
 - `DashboardActivity` to display Instagram posts fetched from official accounts
+  and host a bottom navigation bar
 - `ReportActivity` for viewing repost links
 
 The project uses Gradle Kotlin DSL. To build the project you would typically run:
@@ -20,3 +21,4 @@ The app retrieves user profile information from the [Cicero_V2](https://github.c
 After a successful login, the token and user ID returned by `/api/auth/user-login`
 are used to request `/api/users/{userId}` to display the profile screen.
 The profile screen displays the following fields in order: Urutan, Client ID, Nama, Pangkat, NRP, Satfung, Jabatan, Username IG, Username TikTok and Status.
+After logging in the user is redirected to `DashboardActivity` where a bottom navigation bar lets them open the profile, Instagram content and link report pages.

--- a/app/src/main/java/com/example/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/example/repostapp/DashboardActivity.kt
@@ -1,12 +1,35 @@
 package com.example.repostapp
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class DashboardActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_dashboard)
+
+        val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_navigation)
+        bottomNav.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.nav_profile -> {
+                    val userIntent = Intent(this, UserProfileActivity::class.java).apply {
+                        putExtra("token", intent.getStringExtra("token"))
+                        putExtra("userId", intent.getStringExtra("userId"))
+                    }
+                    startActivity(userIntent)
+                    true
+                }
+                R.id.nav_insta -> true // stay on dashboard
+                R.id.nav_report -> {
+                    startActivity(Intent(this, ReportActivity::class.java))
+                    true
+                }
+                else -> false
+            }
+        }
+        bottomNav.selectedItemId = R.id.nav_insta
         // TODO: fetch and display today's Instagram posts from official account
     }
 }

--- a/app/src/main/java/com/example/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/example/repostapp/LoginActivity.kt
@@ -72,7 +72,7 @@ class LoginActivity : AppCompatActivity() {
                             val token = obj.optString("token", "")
                             val user = obj.optJSONObject("user")
                             val userId = user?.optString("user_id", nrp) ?: nrp
-                            val intent = Intent(this@LoginActivity, UserProfileActivity::class.java).apply {
+                            val intent = Intent(this@LoginActivity, DashboardActivity::class.java).apply {
                                 putExtra("token", token)
                                 putExtra("userId", userId)
                             }

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:layout_width="wrap_content"
+    <FrameLayout
+        android:id="@+id/content_frame"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <TextView
+            android:id="@+id/text_dashboard"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Dashboard Page" />
+    </FrameLayout>
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Dashboard Page" />
+        app:menu="@menu/bottom_nav_menu" />
 </LinearLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/nav_profile"
+        android:icon="@android:drawable/ic_menu_myplaces"
+        android:title="Profil" />
+    <item
+        android:id="@+id/nav_insta"
+        android:icon="@android:drawable/ic_menu_gallery"
+        android:title="Konten" />
+    <item
+        android:id="@+id/nav_report"
+        android:icon="@android:drawable/ic_menu_report_image"
+        android:title="Laporan" />
+</menu>


### PR DESCRIPTION
## Summary
- add bottom navigation menu resource
- update dashboard layout to include a BottomNavigationView
- launch profile and report screens from the dashboard
- redirect login flow to dashboard
- document bottom navigation in README

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859045b27908327ac392e9196a56458