### PR TITLE
Implement IG post list on dashboard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,4 +40,5 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.fragment:fragment-ktx:1.6.2")
     implementation("androidx.viewpager2:viewpager2:1.0.0")
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
 }

--- a/app/src/main/java/com/example/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/example/repostapp/DashboardActivity.kt
@@ -17,7 +17,7 @@ class DashboardActivity : AppCompatActivity() {
 
         val fragments = listOf<Fragment>(
             UserProfileFragment.newInstance(userId, token),
-            DashboardFragment(),
+            DashboardFragment.newInstance(userId, token),
             ReportFragment()
         )
 

--- a/app/src/main/java/com/example/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/example/repostapp/DashboardFragment.kt
@@ -2,11 +2,128 @@ package com.example.repostapp
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.LocalDate
 
 class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
+
+    companion object {
+        private const val ARG_USER_ID = "userId"
+        private const val ARG_TOKEN = "token"
+
+        fun newInstance(userId: String?, token: String?): DashboardFragment {
+            val frag = DashboardFragment()
+            frag.arguments = bundleOf(ARG_USER_ID to userId, ARG_TOKEN to token)
+            return frag
+        }
+    }
+
+    private lateinit var adapter: PostAdapter
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // TODO: fetch and display today's Instagram posts from official account
+
+        adapter = PostAdapter(mutableListOf())
+        val recycler = view.findViewById<RecyclerView>(R.id.recycler_posts)
+        recycler.layoutManager = LinearLayoutManager(requireContext())
+        recycler.adapter = adapter
+
+        val userId = arguments?.getString(ARG_USER_ID) ?: ""
+        val token = arguments?.getString(ARG_TOKEN) ?: ""
+        if (userId.isNotBlank() && token.isNotBlank()) {
+            fetchTodayPosts(userId, token)
+        }
+    }
+
+    private fun fetchTodayPosts(userId: String, token: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val client = OkHttpClient()
+            val profileReq = Request.Builder()
+                .url("https://papiqo.com/api/users/$userId")
+                .header("Authorization", "Bearer $token")
+                .build()
+            try {
+                client.newCall(profileReq).execute().use { resp ->
+                    val body = resp.body?.string()
+                    if (resp.isSuccessful) {
+                        val data = try {
+                            JSONObject(body ?: "{}").optJSONObject("data")
+                        } catch (_: Exception) { null }
+                        val username = data?.optString("insta") ?: ""
+                        if (username.isNotBlank()) {
+                            fetchPostsByUsername(username, token)
+                        } else {
+                            withContext(Dispatchers.Main) {
+                                Toast.makeText(requireContext(), "Username IG tidak ditemukan", Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    } else {
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(requireContext(), "Gagal memuat profil", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "Gagal terhubung ke server", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchPostsByUsername(username: String, token: String) {
+        val client = OkHttpClient()
+        val url = "https://papiqo.com/api/insta/rapid-posts?username=$username&limit=20"
+        val req = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $token")
+            .build()
+        try {
+            client.newCall(req).execute().use { resp ->
+                val body = resp.body?.string()
+                withContext(Dispatchers.Main) {
+                    if (resp.isSuccessful) {
+                        val arr = try {
+                            JSONObject(body ?: "{}").optJSONArray("data")
+                        } catch (_: Exception) { JSONArray() }
+                        val today = LocalDate.now().toString()
+                        val posts = mutableListOf<InstaPost>()
+                        for (i in 0 until arr.length()) {
+                            val obj = arr.optJSONObject(i) ?: continue
+                            val created = obj.optString("created_at")
+                            if (created.startsWith(today)) {
+                                posts.add(
+                                    InstaPost(
+                                        id = obj.optString("id"),
+                                        caption = obj.optString("caption"),
+                                        createdAt = created
+                                    )
+                                )
+                            }
+                        }
+                        adapter.setData(posts)
+                    } else {
+                        Toast.makeText(requireContext(), "Gagal mengambil posting", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(requireContext(), "Gagal terhubung ke server", Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 }
+

--- a/app/src/main/java/com/example/repostapp/PostAdapter.kt
+++ b/app/src/main/java/com/example/repostapp/PostAdapter.kt
@@ -1,0 +1,45 @@
+package com.example.repostapp
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+data class InstaPost(
+    val id: String,
+    val caption: String?,
+    val createdAt: String
+)
+
+class PostAdapter(private val items: MutableList<InstaPost>) :
+    RecyclerView.Adapter<PostAdapter.PostViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_post, parent, false)
+        return PostViewHolder(view)
+    }
+
+    override fun getItemCount() = items.size
+
+    override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    fun setData(data: List<InstaPost>) {
+        items.clear()
+        items.addAll(data)
+        notifyDataSetChanged()
+    }
+
+    class PostViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val captionText: TextView = itemView.findViewById(R.id.text_caption)
+        private val dateText: TextView = itemView.findViewById(R.id.text_date)
+
+        fun bind(post: InstaPost) {
+            captionText.text = post.caption ?: ""
+            dateText.text = post.createdAt
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -3,9 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/text_dashboard"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Dashboard Page" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_posts"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </FrameLayout>

--- a/app/src/main/res/layout/item_post.xml
+++ b/app/src/main/res/layout/item_post.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/text_caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/text_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- show RecyclerView in dashboard page
- fetch today's IG posts via RapidAPI endpoint
- add RecyclerView adapter and item layout
- pass login info to DashboardFragment
- include RecyclerView dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68590adf1610832793596345462e4946