### PR TITLE
Add persistent login redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This project contains a minimal Android application skeleton. The app includes several activities:
 
-- `MainActivity` as a landing page
+- `MainActivity` as a landing page. It checks for a saved JWT token and
+  immediately opens the dashboard when the token is valid.
 - `LoginActivity` for user authentication
 - `UserProfileActivity` to show user details
 - `DashboardActivity` to display Instagram posts fetched from official accounts

--- a/app/src/main/java/com/example/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/example/repostapp/LoginActivity.kt
@@ -6,6 +6,7 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -72,6 +73,12 @@ class LoginActivity : AppCompatActivity() {
                             val token = obj.optString("token", "")
                             val user = obj.optJSONObject("user")
                             val userId = user?.optString("user_id", nrp) ?: nrp
+                            val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+                            prefs.edit {
+                                putString("token", token)
+                                putString("userId", userId)
+                            }
+
                             val intent = Intent(this@LoginActivity, DashboardActivity::class.java).apply {
                                 putExtra("token", token)
                                 putExtra("userId", userId)

--- a/app/src/main/java/com/example/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/example/repostapp/MainActivity.kt
@@ -2,18 +2,63 @@ package com.example.repostapp
 
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        // After showing the landing page for 5 seconds, navigate to the login page
-        Handler(Looper.getMainLooper()).postDelayed({
-            startActivity(Intent(this, LoginActivity::class.java))
-            finish()
-        }, 5000)
+
+        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val token = prefs.getString("token", null)
+        val userId = prefs.getString("userId", null)
+        if (!token.isNullOrBlank() && !userId.isNullOrBlank()) {
+            validateToken(token, userId)
+        } else {
+            navigateToLogin()
+        }
+    }
+
+    private fun validateToken(token: String, userId: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val client = OkHttpClient()
+            val request = Request.Builder()
+                .url("https://papiqo.com/api/users/$userId")
+                .header("Authorization", "Bearer $token")
+                .build()
+            try {
+                client.newCall(request).execute().use { resp ->
+                    withContext(Dispatchers.Main) {
+                        if (resp.isSuccessful) {
+                            navigateToDashboard(token, userId)
+                        } else {
+                            navigateToLogin()
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+                withContext(Dispatchers.Main) { navigateToLogin() }
+            }
+        }
+    }
+
+    private fun navigateToDashboard(token: String, userId: String) {
+        val intent = Intent(this, DashboardActivity::class.java).apply {
+            putExtra("token", token)
+            putExtra("userId", userId)
+        }
+        startActivity(intent)
+        finish()
+    }
+
+    private fun navigateToLogin() {
+        startActivity(Intent(this, LoginActivity::class.java))
+        finish()
     }
 }


### PR DESCRIPTION
## Summary
- store token and userId in shared preferences when logging in
- check saved token in `MainActivity` and validate against `/api/users/{userId}`
- automatically open dashboard when token is valid, otherwise go to login
- document this new behavior in README

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685910786ca08327a7bc91cad71744bf