### PR TITLE
Fix daily content fetch date parsing

### DIFF
--- a/app/src/main/java/com/example/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/example/repostapp/DashboardFragment.kt
@@ -96,11 +96,15 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                                 JSONObject(body ?: "{}").optJSONArray("data")
                             } catch (_: Exception) { JSONArray() }
                             val posts = mutableListOf<InstaPost>()
-                            val today = java.time.LocalDate.now().toString()
+                            val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                            val today = java.time.LocalDate.now()
                             for (i in 0 until arr.length()) {
                                 val obj = arr.optJSONObject(i) ?: continue
                                 val created = obj.optString("created_at")
-                                if (created.take(10) == today) {
+                                val createdDate = try {
+                                    java.time.LocalDateTime.parse(created, formatter).toLocalDate()
+                                } catch (_: Exception) { null }
+                                if (createdDate == today) {
                                     posts.add(
                                         InstaPost(
                                             id = obj.optString("shortcode"),


### PR DESCRIPTION
## Summary
- parse API date using `LocalDateTime` and only compare the date portion

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591d10287883278b7d3e9e49222367