### PR TITLE
Fix timezone for today's posts

### DIFF
--- a/app/src/main/java/com/example/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/example/repostapp/DashboardFragment.kt
@@ -109,7 +109,9 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                                 val created = obj.optString("created_at")
                                 val createdDate = try {
                                     if (created.contains("T")) {
-                                        java.time.OffsetDateTime.parse(created).toLocalDate()
+                                        java.time.OffsetDateTime.parse(created)
+                                            .atZoneSameInstant(java.time.ZoneId.systemDefault())
+                                            .toLocalDate()
                                     } else {
                                         java.time.LocalDateTime.parse(created, formatter).toLocalDate()
                                     }


### PR DESCRIPTION
## Summary
- ensure dashboard filters posts by local date when server timestamp includes offset

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591ff957cc8327b47fca21d4738dc8