### PR TITLE
Implement auto download & sharing workflow

### DIFF
--- a/app/src/main/java/com/example/repostapp/PostAdapter.kt
+++ b/app/src/main/java/com/example/repostapp/PostAdapter.kt
@@ -16,7 +16,8 @@ data class InstaPost(
     val isVideo: Boolean = false,
     val videoUrl: String? = null,
     val sourceUrl: String? = null,
-    var downloaded: Boolean = false
+    var downloaded: Boolean = false,
+    var localPath: String? = null
 )
 
 class PostAdapter(


### PR DESCRIPTION
## Summary
- mark each Instagram post with local path information
- auto-download content on first tap
- display progress bar while downloading and set check mark once done
- provide share & report dialog when content already downloaded
- share downloaded file if present and copy caption to clipboard

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68594c45eddc832791d81b3509fd9bd2