### PR TITLE
Improve sharing to use FileProvider

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,15 @@
         <activity android:name=".DashboardActivity" />
         <activity android:name=".UserProfileActivity" />
         <activity android:name=".LoginActivity" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/example/repostapp/DashboardFragment.kt
@@ -243,11 +243,20 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
     private fun sharePost(post: InstaPost) {
         val fileName = post.id + if (post.isVideo) ".mp4" else ".jpg"
         val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-        val file = java.io.File(dir, fileName)
+        val file = if (!post.localPath.isNullOrBlank()) {
+            java.io.File(post.localPath!!)
+        } else {
+            java.io.File(dir, fileName)
+        }
         val intent = Intent(Intent.ACTION_SEND)
         intent.type = if (post.isVideo) "video/*" else "image/*"
         if (file.exists()) {
-            intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(file))
+            val uri = androidx.core.content.FileProvider.getUriForFile(
+                requireContext(),
+                requireContext().packageName + ".fileprovider",
+                file
+            )
+            intent.putExtra(Intent.EXTRA_STREAM, uri)
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         } else {
             val url = if (post.isVideo) post.videoUrl else post.sourceUrl ?: post.imageUrl

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <external-path name="download" path="Download/" />
+</paths>


### PR DESCRIPTION
## Summary
- add FileProvider for sharing local files
- configure provider paths for downloads
- ensure DashboardFragment shares the downloaded file using FileProvider

## Testing
- `gradle assembleDebug -x lint` *(fails: environment lacks Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68596a0868e48327b238349edd96fb44