### PR TITLE
Fix image download source for non-video posts

### DIFF
--- a/app/src/main/java/com/example/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/example/repostapp/DashboardFragment.kt
@@ -192,7 +192,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
     }
 
     private fun downloadPost(post: InstaPost) {
-        val url = if (post.isVideo) post.videoUrl else post.sourceUrl ?: post.imageUrl
+        val url = if (post.isVideo) post.videoUrl else post.imageUrl ?: post.sourceUrl
         if (url.isNullOrBlank()) return
         val fileName = post.id + if (post.isVideo) ".mp4" else ".jpg"
         progressBar.visibility = View.VISIBLE
@@ -259,7 +259,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
             intent.putExtra(Intent.EXTRA_STREAM, uri)
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         } else {
-            val url = if (post.isVideo) post.videoUrl else post.sourceUrl ?: post.imageUrl
+            val url = if (post.isVideo) post.videoUrl else post.imageUrl ?: post.sourceUrl
             if (!url.isNullOrBlank()) intent.putExtra(Intent.EXTRA_TEXT, url)
         }
         val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager


### PR DESCRIPTION
## Summary
- prefer `imageUrl` when downloading or sharing non-video posts

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68596bb74350832787f79474eab8ad6d