### PR TITLE
Add logout button on profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ After a successful login, the token and user ID returned by `/api/auth/user-logi
 are used to request `/api/users/{userId}` to display the profile screen.
 The profile screen displays the following fields in order: Urutan, Client ID, Nama, Pangkat, NRP, Satfung, Jabatan, Username IG, Username TikTok and Status.
 After logging in the user is redirected to `DashboardActivity` where a bottom navigation bar lets them open the profile, Instagram content and link report pages.
+A logout button is provided at the bottom of the profile page.
 
 ## Documentation
 

--- a/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
@@ -3,6 +3,9 @@ package com.example.repostapp
 import android.os.Bundle
 import android.widget.TextView
 import android.widget.Toast
+import android.widget.Button
+import android.content.Intent
+import androidx.core.content.edit
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +21,13 @@ class UserProfileActivity : AppCompatActivity() {
         setContentView(R.layout.activity_profile)
         val userId = intent.getStringExtra("userId") ?: ""
         val token = intent.getStringExtra("token") ?: ""
+        findViewById<Button>(R.id.button_logout).setOnClickListener {
+            val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+            prefs.edit { clear() }
+            val intent = Intent(this, MainActivity::class.java)
+            startActivity(intent)
+            finish()
+        }
         if (userId.isNotBlank() && token.isNotBlank()) {
             fetchProfile(userId, token)
         }

--- a/app/src/main/java/com/example/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileFragment.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
+import android.widget.Button
+import android.content.Intent
+import android.content.Context
+import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.CoroutineScope
@@ -31,6 +35,13 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
         super.onViewCreated(view, savedInstanceState)
         val userId = arguments?.getString(ARG_USER_ID) ?: ""
         val token = arguments?.getString(ARG_TOKEN) ?: ""
+        view.findViewById<Button>(R.id.button_logout).setOnClickListener {
+            val prefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+            prefs.edit { clear() }
+            val intent = Intent(requireContext(), MainActivity::class.java)
+            startActivity(intent)
+            activity?.finish()
+        }
         if (userId.isNotBlank() && token.isNotBlank()) {
             fetchProfile(userId, token, view)
         }

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -181,11 +181,21 @@
                 android:layout_height="wrap_content"
                 android:text="Username TikTok:" />
 
-            <TextView
-                android:id="@+id/text_status"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Status:" />
-        </LinearLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/text_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Status:" />
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/button_logout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Logout"
+        android:layout_marginTop="24dp"
+        app:layout_constraintTop_toBottomOf="@id/info_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>


### PR DESCRIPTION
## Summary
- add logout button to profile layout
- clear auth preferences in profile activity
- handle logout in profile fragment
- document logout button in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598edac7288327b7251e8507ac2fc0