### PR TITLE
Implement profile pic with status indicator

### DIFF
--- a/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
@@ -4,9 +4,11 @@ import android.os.Bundle
 import android.widget.TextView
 import android.widget.Toast
 import android.widget.Button
+import android.widget.ImageView
 import android.content.Intent
 import androidx.core.content.edit
 import androidx.appcompat.app.AppCompatActivity
+import com.bumptech.glide.Glide
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -69,8 +71,22 @@ class UserProfileActivity : AppCompatActivity() {
                                 (data?.optString("jabatan") ?: "")
                             findViewById<TextView>(R.id.text_tiktok).text =
                                 (data?.optString("tiktok") ?: "")
-                            findViewById<TextView>(R.id.text_status).text =
-                                (data?.optString("status") ?: "")
+                            val statusText = data?.optString("status") ?: ""
+                            findViewById<TextView>(R.id.text_status).text = statusText
+
+                            val avatarUrl = data?.optString("profile_pic_url") ?: ""
+                            Glide.with(this@UserProfileActivity)
+                                .load(avatarUrl)
+                                .placeholder(R.drawable.profile_avatar_placeholder)
+                                .error(R.drawable.profile_avatar_placeholder)
+                                .into(findViewById(R.id.image_avatar))
+
+                            val statusImage = if (statusText.equals("true", true)) {
+                                R.drawable.ic_status_true
+                            } else {
+                                R.drawable.ic_status_false
+                            }
+                            findViewById<ImageView>(R.id.image_status).setImageResource(statusImage)
                             fetchStats(token, insta)
                         } else {
                             Toast.makeText(this@UserProfileActivity, "Gagal memuat profil", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileFragment.kt
@@ -7,9 +7,11 @@ import android.widget.Toast
 import android.widget.Button
 import android.content.Intent
 import android.content.Context
+import android.widget.ImageView
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -80,8 +82,22 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
                                 (data?.optString("jabatan") ?: "")
                             rootView.findViewById<TextView>(R.id.text_tiktok).text =
                                 (data?.optString("tiktok") ?: "")
-                            rootView.findViewById<TextView>(R.id.text_status).text =
-                                (data?.optString("status") ?: "")
+                            val statusText = data?.optString("status") ?: ""
+                            rootView.findViewById<TextView>(R.id.text_status).text = statusText
+
+                            val avatarUrl = data?.optString("profile_pic_url") ?: ""
+                            Glide.with(this@UserProfileFragment)
+                                .load(avatarUrl)
+                                .placeholder(R.drawable.profile_avatar_placeholder)
+                                .error(R.drawable.profile_avatar_placeholder)
+                                .into(rootView.findViewById(R.id.image_avatar))
+
+                            val statusImage = if (statusText.equals("true", true)) {
+                                R.drawable.ic_status_true
+                            } else {
+                                R.drawable.ic_status_false
+                            }
+                            rootView.findViewById<ImageView>(R.id.image_status).setImageResource(statusImage)
                             fetchStats(token, insta, rootView)
                         } else {
                             Toast.makeText(requireContext(), "Gagal memuat profil", Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/drawable/ic_status_false.xml
+++ b/app/src/main/res/drawable/ic_status_false.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#F44336"
+        android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_status_true.xml
+++ b/app/src/main/res/drawable/ic_status_true.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#4CAF50"
+        android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+</vector>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -30,6 +30,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
+        <ImageView
+            android:id="@+id/image_status"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_margin="4dp"
+            android:src="@drawable/ic_status_true"
+            app:layout_constraintBottom_toBottomOf="@id/image_avatar"
+            app:layout_constraintEnd_toEndOf="@id/image_avatar" />
+
         <TextView
             android:id="@+id/text_username"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- load profile avatar from `profile_pic_url`
- show green check or red X overlay based on status
- add drawable icons and overlay `ImageView`

## Testing
- `gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685996ffadfc8327b5d7a77fd2b63ccf