### PR TITLE
Fix profile layout and keep circular avatar

### DIFF
--- a/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileActivity.kt
@@ -62,8 +62,6 @@ class UserProfileActivity : AppCompatActivity() {
                             val avatarUrl = data?.optString("profile_pic_url") ?: ""
                             val fullAvatarUrl = if (avatarUrl.startsWith("http"))
                                 avatarUrl else "https://papiqo.com" + avatarUrl
-                            findViewById<TextView>(R.id.text_profile_url).text =
-                                fullAvatarUrl
                             findViewById<TextView>(R.id.text_name).text =
                                 (data?.optString("title") ?: "") + " " + (data?.optString("nama") ?: "")
                             findViewById<TextView>(R.id.text_nrp).text =
@@ -81,6 +79,7 @@ class UserProfileActivity : AppCompatActivity() {
                                 .load(fullAvatarUrl)
                                 .placeholder(R.drawable.profile_avatar_placeholder)
                                 .error(R.drawable.profile_avatar_placeholder)
+                                .circleCrop()
                                 .into(findViewById(R.id.image_avatar))
 
                             val statusImage = if (statusText.equals("true", true)) {
@@ -120,7 +119,6 @@ class UserProfileActivity : AppCompatActivity() {
                     (stats?.optInt("follower_count") ?: 0).toString()
                 findViewById<TextView>(R.id.stat_following).text =
                     (stats?.optInt("following_count") ?: 0).toString()
-                findViewById<TextView>(R.id.text_raw_data).text = raw ?: ""
             }
         }
     }

--- a/app/src/main/java/com/example/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/example/repostapp/UserProfileFragment.kt
@@ -73,8 +73,6 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
                             val avatarUrl = data?.optString("profile_pic_url") ?: ""
                             val fullAvatarUrl = if (avatarUrl.startsWith("http"))
                                 avatarUrl else "https://papiqo.com" + avatarUrl
-                            rootView.findViewById<TextView>(R.id.text_profile_url).text =
-                                fullAvatarUrl
                             rootView.findViewById<TextView>(R.id.text_name).text =
                                 (data?.optString("title") ?: "") + " " + (data?.optString("nama") ?: "")
                             rootView.findViewById<TextView>(R.id.text_nrp).text =
@@ -92,6 +90,7 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
                                 .load(fullAvatarUrl)
                                 .placeholder(R.drawable.profile_avatar_placeholder)
                                 .error(R.drawable.profile_avatar_placeholder)
+                                .circleCrop()
                                 .into(rootView.findViewById(R.id.image_avatar))
 
                             val statusImage = if (statusText.equals("true", true)) {
@@ -131,7 +130,6 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
                     (stats?.optInt("follower_count") ?: 0).toString()
                 rootView.findViewById<TextView>(R.id.stat_following).text =
                     (stats?.optInt("following_count") ?: 0).toString()
-                rootView.findViewById<TextView>(R.id.text_raw_data).text = raw ?: ""
             }
         }
     }

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -241,36 +241,13 @@
 
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/text_profile_url"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:autoLink="web"
-            android:textColor="@android:color/holo_blue_dark"
-            app:layout_constraintTop_toBottomOf="@id/info_container"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
         <Button
             android:id="@+id/button_logout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Logout"
             android:layout_marginTop="24dp"
-            app:layout_constraintTop_toBottomOf="@id/text_profile_url"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <TextView
-            android:id="@+id/text_raw_data"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:fontFamily="monospace"
-            android:textIsSelectable="true"
-            app:layout_constraintTop_toBottomOf="@id/button_logout"
+            app:layout_constraintTop_toBottomOf="@id/info_container"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- remove profile URL and raw JSON fields from the profile screen
- keep avatar image circular after loading

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac430e70c8327a53f6a322daa484d