### PR TITLE
Rename package to com.cicero.repostapp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    namespace = "com.example.repostapp"
+    namespace = "com.cicero.repostapp"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.example.repostapp"
+        applicationId = "com.cicero.repostapp"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.repostapp"
+<manifest package="com.cicero.repostapp"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.Manifest
 import android.content.ClipData

--- a/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.content.Intent
 import android.os.Bundle

--- a/app/src/main/java/com/cicero/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.Manifest
 import android.content.Intent

--- a/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
+++ b/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.os.Bundle
 import android.widget.Button

--- a/app/src/main/java/com/cicero/repostapp/ReportFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportFragment.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/java/com/cicero/repostapp/UserProfileActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/UserProfileActivity.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.os.Bundle
 import android.widget.TextView

--- a/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
@@ -1,4 +1,4 @@
-package com.example.repostapp
+package com.cicero.repostapp
 
 import android.os.Bundle
 import android.view.View


### PR DESCRIPTION
## Summary
- rename app package from `com.example.repostapp` to `com.cicero.repostapp`
- update manifest and Gradle config
- move source files under new namespace

## Testing
- `gradle help`

------
https://chatgpt.com/codex/tasks/task_e_685aca07fdac832798dfe8373bde7f93