### PR TITLE
Remove download confirmation dialog

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -196,17 +196,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         if (downloadedIds.contains(post.id)) {
             showShareDialog(post)
         } else {
-            if (!post.isVideo) {
-                requestStorageAndDownload(post)
-            } else {
-                androidx.appcompat.app.AlertDialog.Builder(requireContext())
-                    .setMessage("Download konten ini?")
-                    .setPositiveButton("Download") { _, _ ->
-                        requestStorageAndDownload(post)
-                    }
-                    .setNegativeButton("Batal", null)
-                    .show()
-            }
+            requestStorageAndDownload(post)
         }
     }
 


### PR DESCRIPTION
## Summary
- remove confirmation prompt for downloading videos in DashboardFragment
- always invoke download on click when post is not already stored

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acf0bfc7c8327b4ee829678db563a