### PR TITLE
Use list shortcode for reports

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -331,6 +331,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                         val intent = Intent(requireContext(), ReportActivity::class.java).apply {
                             putExtra(ReportActivity.EXTRA_IMAGE_URL, post.imageUrl)
                             putExtra(ReportActivity.EXTRA_CAPTION, post.caption)
+                            putExtra(ReportActivity.EXTRA_SHORTCODE, post.id)
                         }
                         startActivity(intent)
                     }

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -27,6 +27,7 @@ class ReportActivity : AppCompatActivity() {
     companion object {
         const val EXTRA_IMAGE_URL = "image_url"
         const val EXTRA_CAPTION = "caption"
+        const val EXTRA_SHORTCODE = "shortcode"
     }
 
     private data class Platform(
@@ -40,6 +41,7 @@ class ReportActivity : AppCompatActivity() {
     private lateinit var platforms: List<Platform>
     private lateinit var token: String
     private lateinit var userId: String
+    private var shortcode: String? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_report)
@@ -60,6 +62,7 @@ class ReportActivity : AppCompatActivity() {
             val captionView = findViewById<TextView>(R.id.caption_preview)
             captionView.text = caption
         }
+        shortcode = intent.getStringExtra(EXTRA_SHORTCODE)
 
         platforms = listOf(
             Platform(
@@ -248,9 +251,9 @@ class ReportActivity : AppCompatActivity() {
             }
 
             if (valid) {
-                val shortcode = extractShortcode(links["instagram"]!!)
+                val shortcodeVal = shortcode ?: extractShortcode(links["instagram"]!!)
                 val json = JSONObject().apply {
-                    put("shortcode", shortcode ?: "")
+                    put("shortcode", shortcodeVal ?: "")
                     put("user_id", userId)
                     put("instagram_link", links["instagram"])
                     put("facebook_link", links["facebook"])


### PR DESCRIPTION
## Summary
- add EXTRA_SHORTCODE constant to `ReportActivity`
- keep the post shortcode when starting `ReportActivity`
- default to that shortcode when sending a report

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adc294ca483279421f8a51d583bbc