### PR TITLE
Clear placeholder links for report page

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -70,35 +70,35 @@ class ReportActivity : AppCompatActivity() {
                 R.id.text_instagram,
                 R.id.button_paste_instagram,
                 "Paste link Instagram",
-                "https://instagram.com/placeholder"
+                ""
             ),
             Platform(
                 "facebook",
                 R.id.text_facebook,
                 R.id.button_paste_facebook,
                 "Paste link Facebook",
-                "https://facebook.com/placeholder"
+                ""
             ),
             Platform(
                 "twitter",
                 R.id.text_twitter,
                 R.id.button_paste_twitter,
                 "Paste link Twitter",
-                "https://twitter.com/placeholder"
+                ""
             ),
             Platform(
                 "tiktok",
                 R.id.text_tiktok,
                 R.id.button_paste_tiktok,
                 "Paste link TikTok",
-                "https://www.tiktok.com/placeholder"
+                ""
             ),
             Platform(
                 "youtube",
                 R.id.text_youtube,
                 R.id.button_paste_youtube,
                 "Paste link YouTube",
-                "https://youtu.be/placeholder"
+                ""
             )
         )
 

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -29,7 +29,7 @@
             android:id="@+id/text_instagram"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="https://instagram.com/placeholder"
+            android:text=""
             android:paddingBottom="8dp" />
 
         <Button
@@ -44,7 +44,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="https://facebook.com/placeholder"
+            android:text=""
             android:paddingBottom="8dp" />
 
         <Button
@@ -59,7 +59,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="https://twitter.com/placeholder"
+            android:text=""
             android:paddingBottom="8dp" />
 
         <Button
@@ -74,7 +74,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="https://www.tiktok.com/placeholder"
+            android:text=""
             android:paddingBottom="8dp" />
 
         <Button
@@ -89,7 +89,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="https://youtu.be/placeholder"
+            android:text=""
             android:paddingBottom="8dp" />
 
         <Button


### PR DESCRIPTION
## Summary
- remove placeholder URLs from report fields
- default link text is now blank so unfilled links are `null`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b766370608327b158d0bfa861632a