### PR TITLE
Prompt user to create download directory

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -188,6 +188,12 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
     }
 
     private fun handlePostClicked(post: InstaPost) {
+        ensureDownloadDir {
+            proceedWithPost(post)
+        }
+    }
+
+    private fun proceedWithPost(post: InstaPost) {
         val exists = checkIfFileExists(post)
 
         if (exists) {
@@ -209,12 +215,30 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         }
     }
 
+    private fun ensureDownloadDir(onReady: () -> Unit) {
+        val dir = java.io.File(Environment.getExternalStorageDirectory(), "CiceroReposterApp")
+        if (dir.exists()) {
+            onReady()
+            return
+        }
+
+        androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setMessage("Folder CiceroReposterApp tidak ditemukan. Klik OK untuk membuat folder.")
+            .setPositiveButton("OK") { _, _ ->
+                dir.mkdirs()
+                if (!dir.exists()) {
+                    Toast.makeText(requireContext(), "Gagal membuat folder", Toast.LENGTH_SHORT).show()
+                } else {
+                    onReady()
+                }
+            }
+            .setNegativeButton("Batal", null)
+            .show()
+    }
+
     private fun checkIfFileExists(post: InstaPost): Boolean {
         val fileName = post.id + if (post.isVideo) ".mp4" else ".jpg"
         val dir = java.io.File(Environment.getExternalStorageDirectory(), "CiceroReposterApp")
-        if (!dir.exists()) {
-            dir.mkdirs()
-        }
         val file = if (!post.localPath.isNullOrBlank()) {
             java.io.File(post.localPath!!)
         } else {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,6 +19,8 @@ and the user identifier. These values are saved in `SharedPreferences` under the
 After a successful login the dashboard fetches Instagram posts via
 `/api/insta/posts?client_id=<id>` and displays today's content. Tapping a post
 will download it to a public directory named **CiceroReposterApp** and open a share dialog.
+If the directory does not yet exist you will be prompted to create it before the
+download proceeds.
 The dialog lets you share the file, **Kirim Link** to open the reporting form,
 and when a post already shows a check mark you will also see **Laporan WhatsApp**
 to directly forward the Instagram link via WhatsApp.


### PR DESCRIPTION
## Summary
- add an `ensureDownloadDir` helper that asks to create `CiceroReposterApp`
- invoke the helper before handling post clicks
- document download folder prompt in usage docs

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf25b05a08327b9cdce3cbe7517b1