### PR TITLE
Set target SDK to API 29

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     defaultConfig {
         applicationId = "com.cicero.repostapp"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 29
         versionCode = 1
         versionName = "1.0"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
-        android:theme="@style/Theme.CiceroReposter">
+        android:theme="@style/Theme.CiceroReposter"
+        android:requestLegacyExternalStorage="true">
         <activity android:name=".ReportActivity" />
         <activity android:name=".DashboardActivity" />
         <activity android:name=".UserProfileActivity" />


### PR DESCRIPTION
## Summary
- update target SDK to 29
- enable legacy storage mode

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf5105bb48327adbb6b27e5b51c7a