### PR TITLE
Update compileSdk and AGP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.cicero.repostapp"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.cicero.repostapp"
@@ -33,14 +33,14 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.fragment:fragment-ktx:1.6.2")
     implementation("androidx.viewpager2:viewpager2:1.0.0")
-    implementation("androidx.recyclerview:recyclerview:1.3.2")
+    implementation("androidx.recyclerview:recyclerview:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("com.github.bumptech.glide:glide:4.16.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "8.1.0" apply false
+    id("com.android.application") version "8.6.0" apply false
     kotlin("android") version "1.9.20" apply false
 }


### PR DESCRIPTION
## Summary
- update Android Gradle plugin version to 8.6.0
- bump compileSdk to 35
- update core-ktx and recyclerview to latest versions

## Testing
- `gradle tasks --all` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_685bfc1f7fbc8327b677b7ca9026c450