### PR TITLE
Fix storage on Android 12+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,15 +2,12 @@
 <manifest package="com.cicero.repostapp"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
-        android:theme="@style/Theme.CiceroReposter"
-        android:requestLegacyExternalStorage="true">
+        android:theme="@style/Theme.CiceroReposter">
         <activity android:name=".ReportActivity" />
         <activity android:name=".DashboardActivity" />
         <activity android:name=".UserProfileActivity" />

--- a/app/src/main/java/com/cicero/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/MainActivity.kt
@@ -1,13 +1,8 @@
 package com.cicero.repostapp
 
-import android.Manifest
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.provider.Settings
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import android.widget.Button
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -18,12 +13,6 @@ import okhttp3.Request
 
 class MainActivity : AppCompatActivity() {
 
-    private val requestPermission =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-            if (!granted) {
-                openStoragePermissionSettings()
-            }
-        }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -31,7 +20,6 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.setLogo(R.mipmap.ic_launcher_round)
         supportActionBar?.setDisplayUseLogoEnabled(true)
 
-        checkStoragePermission()
 
         val prefs = getSharedPreferences("auth", MODE_PRIVATE)
         val token = prefs.getString("token", null)
@@ -75,19 +63,5 @@ class MainActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun checkStoragePermission() {
-        val permission = Manifest.permission.WRITE_EXTERNAL_STORAGE
-        if (ContextCompat.checkSelfPermission(this, permission) !=
-            android.content.pm.PackageManager.PERMISSION_GRANTED) {
-            requestPermission.launch(permission)
-        }
-    }
-
-    private fun openStoragePermissionSettings() {
-        val intent = Intent(
-            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-            Uri.fromParts("package", packageName, null)
-        )
-        startActivity(intent)
-    }
+    // No external storage permission required when using app-specific storage
 }

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,3 +1,3 @@
 <paths>
-    <external-path name="reposter" path="CiceroReposterApp/" />
+    <external-files-path name="reposter" path="CiceroReposterApp/" />
 </paths>


### PR DESCRIPTION
## Summary
- use app-specific external directory instead of deprecated `Environment.getExternalStorageDirectory`
- drop legacy storage permissions
- update FileProvider paths

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0169e1f88327b1da2155ce789ed9