### PR TITLE
Add WhatsApp report sharing

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -23,4 +23,4 @@ If the directory does not yet exist you will be prompted to create it before the
 download proceeds.
 The dialog lets you share the file, **Kirim Link** to open the reporting form,
 and when a post already shows a check mark you will also see **Laporan WhatsApp**
-to directly forward the Instagram link via WhatsApp.
+which now sends the full report message retrieved from the backend via WhatsApp.


### PR DESCRIPTION
## Summary
- let DashboardFragment store token and userId
- allow sharing full report via WhatsApp once a post is reported
- document updated WhatsApp behaviour

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0fbfc520832787f2f05099cef954