### PR TITLE
Add splash screen for token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Cicero Reposter
 
-This project contains a minimal Android application skeleton. The app includes several activities:
+This project contains a minimal Android application skeleton. The app includes
+several activities:
 
-- `MainActivity` as a landing page. It checks for a saved JWT token and
-  immediately opens the dashboard when the token is valid.
+- `SplashActivity` shows the app logo and validates any saved JWT token before
+  continuing to the next screen.
+- `MainActivity` acts as a landing page with a short introduction and a **Login**
+  button.
 - `LoginActivity` for user authentication
 - `UserProfileActivity` to show user details
 - `DashboardActivity` to display Instagram posts fetched from official accounts

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,14 @@
         <activity android:name=".DashboardActivity" />
         <activity android:name=".UserProfileActivity" />
         <activity android:name=".LoginActivity" />
+        <activity
+            android:name=".SplashActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
@@ -23,11 +31,6 @@
         </provider>
         <activity
             android:name=".MainActivity"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:exported="true" />
     </application>
 </manifest>

--- a/app/src/main/java/com/cicero/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/MainActivity.kt
@@ -4,12 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import android.widget.Button
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
 
 class MainActivity : AppCompatActivity() {
 
@@ -21,46 +15,10 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.setDisplayUseLogoEnabled(true)
 
 
-        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
-        val token = prefs.getString("token", null)
-        val userId = prefs.getString("userId", null)
-        if (!token.isNullOrBlank() && !userId.isNullOrBlank()) {
-            validateToken(token, userId)
-        }
 
         findViewById<Button>(R.id.button_open_login).setOnClickListener {
             startActivity(Intent(this, LoginActivity::class.java))
         }
-    }
-
-    private fun validateToken(token: String, userId: String) {
-        CoroutineScope(Dispatchers.IO).launch {
-            val client = OkHttpClient()
-            val request = Request.Builder()
-                .url("https://papiqo.com/api/users/$userId")
-                .header("Authorization", "Bearer $token")
-                .build()
-            try {
-                client.newCall(request).execute().use { resp ->
-                    withContext(Dispatchers.Main) {
-                        if (resp.isSuccessful) {
-                            navigateToDashboard(token, userId)
-                        }
-                    }
-                }
-            } catch (_: Exception) {
-                // ignore
-            }
-        }
-    }
-
-    private fun navigateToDashboard(token: String, userId: String) {
-        val intent = Intent(this, DashboardActivity::class.java).apply {
-            putExtra("token", token)
-            putExtra("userId", userId)
-        }
-        startActivity(intent)
-        finish()
     }
 
     // No external storage permission required when using app-specific storage

--- a/app/src/main/java/com/cicero/repostapp/SplashActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/SplashActivity.kt
@@ -1,0 +1,66 @@
+package com.cicero.repostapp
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+class SplashActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        supportActionBar?.hide()
+        setContentView(R.layout.activity_splash)
+
+        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val token = prefs.getString("token", null)
+        val userId = prefs.getString("userId", null)
+        if (!token.isNullOrBlank() && !userId.isNullOrBlank()) {
+            validateToken(token, userId)
+        } else {
+            navigateToLanding()
+        }
+    }
+
+    private fun validateToken(token: String, userId: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val client = OkHttpClient()
+            val request = Request.Builder()
+                .url("https://papiqo.com/api/users/$userId")
+                .header("Authorization", "Bearer $token")
+                .build()
+            try {
+                client.newCall(request).execute().use { resp ->
+                    withContext(Dispatchers.Main) {
+                        if (resp.isSuccessful) {
+                            navigateToDashboard(token, userId)
+                        } else {
+                            navigateToLanding()
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+                withContext(Dispatchers.Main) { navigateToLanding() }
+            }
+        }
+    }
+
+    private fun navigateToLanding() {
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+
+    private fun navigateToDashboard(token: String, userId: String) {
+        val intent = Intent(this, DashboardActivity::class.java).apply {
+            putExtra("token", token)
+            putExtra("userId", userId)
+        }
+        startActivity(intent)
+        finish()
+    }
+}

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:background="@drawable/login_background">
+
+    <ImageView
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:src="@mipmap/ic_launcher_round"
+        android:contentDescription="@string/app_name" />
+
+    <ProgressBar
+        android:id="@+id/progress_splash"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp" />
+
+</LinearLayout>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,18 +6,20 @@ and allow reporting of content links.
 
 ## Activity Flow
 
-1. **MainActivity** – The entry point of the app. It checks for a stored JWT
-   token. If the token is valid it immediately opens `DashboardActivity`,
-   otherwise it redirects the user to `LoginActivity`.
-2. **LoginActivity** – Presents a simple login form (NRP and phone number).
+1. **SplashActivity** – Entry point that shows the logo and checks for a saved
+   JWT token. When valid it opens `DashboardActivity`, otherwise it forwards the
+   user to `MainActivity`.
+2. **MainActivity** – A landing page with a brief explanation and a **Login**
+   button.
+3. **LoginActivity** – Presents a simple login form (NRP and phone number).
    On success it stores the token and user ID in `SharedPreferences` and opens
    the dashboard.
-3. **DashboardActivity** – Hosts a `ViewPager2` with a bottom navigation bar.
+4. **DashboardActivity** – Hosts a `ViewPager2` with a bottom navigation bar.
    It shows two fragments:
    - `UserProfileFragment` – displays user information retrieved from the
      backend API.
    - `DashboardFragment` – lists Instagram posts fetched for the logged in user.
-4. **ReportActivity** – A standalone screen to paste links from various social
+5. **ReportActivity** – A standalone screen to paste links from various social
    media platforms for reporting purposes.
 
 Fragments are kept lightweight so most of the logic resides in the Activities.

--- a/docs/LOGIN_FLOW.md
+++ b/docs/LOGIN_FLOW.md
@@ -2,27 +2,31 @@
 
 This document describes how the application handles user authentication when a landing page is present. The flow follows best practices for security and user experience.
 
-## 1. Landing Page
+## 1. Splash Screen
 
-- **MainActivity** acts as the landing page. It displays a simple introduction and a **Login** button.
-- At startup, the activity checks whether a saved JWT token exists in `SharedPreferences` and validates it against the backend.
-- When the token is still valid, the user is sent directly to `DashboardActivity` (auto-login).
-- If no valid token is found, the user stays on the landing page and can press **Login** to continue.
+- **SplashActivity** appears on launch. It shows the logo and checks if a saved
+  JWT token is still valid.
+- When valid, the dashboard is opened automatically.
+- When not, the user is forwarded to the landing page.
 
-## 2. Login Screen
+## 2. Landing Page
+
+- **MainActivity** displays a short introduction and a **Login** button.
+
+## 3. Login Screen
 
 - **LoginActivity** contains a form for NRP and phone number (as password).
 - Input is validated locally (non-empty fields) and a request is sent over HTTPS to `/api/auth/user-login`.
 - On success, the JWT token and user ID are stored securely and the dashboard is opened.
 - Errors are shown as toast messages, such as "NRP dan password wajib diisi" or "Gagal terhubung ke server".
 
-## 3. Session Management
+## 4. Session Management
 
 - Every network request includes the `Authorization: Bearer <token>` header.
 - When a request returns `401 Unauthorized`, the app requires the user to log in again.
 - Tokens are kept in `SharedPreferences` and cleared on logout.
 
-## 4. Logout
+## 5. Logout
 
 - The profile screen provides a logout button that removes the saved token.
 - After logout, the user is returned to the landing page.


### PR DESCRIPTION
## Summary
- create SplashActivity for initial token check and progress display
- update manifest to use SplashActivity as launcher
- add splash screen layout
- simplify MainActivity by removing token validation
- document the new splash screen behaviour

## Testing
- `./gradlew assembleDebug` *(fails: `gradlew` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c99be5f90832788f2c353f1e63d02