### PR TITLE
Add save login and show password options

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -72,6 +72,19 @@
                             android:inputType="textPassword" />
                     </com.google.android.material.textfield.TextInputLayout>
 
+                    <CheckBox
+                        android:id="@+id/checkbox_show_password"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="Show Password" />
+
+                    <CheckBox
+                        android:id="@+id/checkbox_save_login"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Save Login" />
+
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/button_login"
                         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- update `activity_login.xml` with checkboxes for showing the password and saving credentials
- extend `LoginActivity` to handle the new options and persist credentials

## Testing
- `gradle --version`
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9b3836f88327900475a63ba0495d