### PR TITLE
Add Instagram4j dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,10 @@ android {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
@@ -43,4 +47,6 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("com.github.bumptech.glide:glide:4.16.0")
+    implementation("org.brunocvcunha:instagram4j:1.11")
+    implementation("org.apache.httpcomponents:httpclient:4.5.13")
 }


### PR DESCRIPTION
## Summary
- include `mavenCentral()` repo in app module
- add Instagram4J and Apache HttpClient dependencies

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce893f1548327aa946ad47c2205be