### PR TITLE
Add Insta page to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The app retrieves user profile information from the [Cicero_V2](https://github.c
 After a successful login, the token and user ID returned by `/api/auth/user-login`
 are used to request `/api/users/{userId}` to display the profile screen.
 The profile screen displays @username followed by rank and name, the user's NRP and Instagram statistics (post, follower and following counts). These stats are loaded from the backend and will be fetched on demand if missing. The screen also lists the fields Client ID, Satfung, Jabatan, Username TikTok and Status.
-After logging in the user is redirected to `DashboardActivity` where a bottom navigation bar lets them open the profile, Instagram content and link report pages.
+After logging in the user is redirected to `DashboardActivity` where a bottom navigation bar lets them open the profile, Instagram content, an Instagram login page and link report pages.
 A logout button is provided at the bottom of the profile page.
 
 ## Documentation

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -8,4 +8,8 @@
         android:id="@+id/nav_insta"
         android:icon="@android:drawable/ic_menu_gallery"
         android:title="Konten" />
+    <item
+        android:id="@+id/nav_insta_login"
+        android:icon="@android:drawable/ic_menu_edit"
+        android:title="Insta" />
 </menu>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,10 +17,11 @@ and allow reporting of content links.
    the dashboard. The activity likewise validates an existing token on startup
    to skip the form for returning users.
 4. **DashboardActivity** – Hosts a `ViewPager2` with a bottom navigation bar.
-   It shows two fragments:
+   It shows three fragments:
    - `UserProfileFragment` – displays user information retrieved from the
      backend API.
    - `DashboardFragment` – lists Instagram posts fetched for the logged in user.
+   - `InstaFragment` – lets the user log in to Instagram.
 5. **ReportActivity** – A standalone screen to paste links from various social
    media platforms for reporting purposes.
 


### PR DESCRIPTION
## Summary
- add `nav_insta_login` item to the bottom navigation menu
- document the new `InstaFragment` page in ARCHITECTURE
- mention the Instagram login page in README

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d093acb988327bd18e313d5ff1cd2