### PR TITLE
Fix two-factor login call

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaFragment.kt
@@ -65,7 +65,7 @@ class InstaFragment : Fragment(R.layout.fragment_insta) {
                 .setPositiveButton("Verifikasi") { _, _ ->
                     CoroutineScope(Dispatchers.IO).launch {
                         try {
-                            insta.finishTwoFactorLogin(input.text.toString(), result.two_factor_info.two_factor_identifier)
+                            insta.login(input.text.toString())
                             withContext(Dispatchers.Main) {
                                 Toast.makeText(requireContext(), "Login berhasil", Toast.LENGTH_SHORT).show()
                             }


### PR DESCRIPTION
## Summary
- remove nonexistent `finishTwoFactorLogin` call
- use library's `login` method with verification code

## Testing
- `gradlew` (fails: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_685d193883fc8327878c6249cf381516