### PR TITLE
Add Instagram4j login with 2FA handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,4 +44,5 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("com.github.bumptech.glide:glide:4.16.0")
+    implementation("com.github.instagram4j:instagram4j:2.0.7")
 }

--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -5,7 +5,19 @@ import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import com.github.instagram4j.instagram4j.IGClient
+import com.github.instagram4j.instagram4j.IGClient.Builder.LoginHandler
+import com.github.instagram4j.instagram4j.utils.IGChallengeUtils
+import com.github.instagram4j.instagram4j.exceptions.IGLoginException
+import java.util.concurrent.Callable
 
 class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -16,10 +28,62 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
             val user = username.text.toString().trim()
             val pass = password.text.toString().trim()
             if (user.isNotBlank() && pass.isNotBlank()) {
-                Toast.makeText(requireContext(), "Login: $user", Toast.LENGTH_SHORT).show()
+                performLogin(user, pass)
             } else {
                 Toast.makeText(requireContext(), "Username dan password wajib diisi", Toast.LENGTH_SHORT).show()
             }
+        }
+    }
+
+    private fun performLogin(user: String, pass: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val codePrompt = Callable {
+                runBlocking { promptCode("Masukkan kode verifikasi") }
+            }
+
+            val twoFactorHandler = LoginHandler { client, resp ->
+                IGChallengeUtils.resolveTwoFactor(client, resp, codePrompt)
+            }
+            val challengeHandler = LoginHandler { client, resp ->
+                IGChallengeUtils.resolveChallenge(client, resp, codePrompt)
+            }
+
+            try {
+                IGClient.builder()
+                    .username(user)
+                    .password(pass)
+                    .onTwoFactor(twoFactorHandler)
+                    .onChallenge(challengeHandler)
+                    .login()
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "Login Instagram berhasil", Toast.LENGTH_SHORT).show()
+                }
+            } catch (e: IGLoginException) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "Gagal login: ${e.loginResponse.message}", Toast.LENGTH_SHORT).show()
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "Error: ${e.localizedMessage}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    private suspend fun promptCode(title: String): String = withContext(Dispatchers.Main) {
+        suspendCancellableCoroutine { cont ->
+            val input = EditText(requireContext())
+            AlertDialog.Builder(requireContext())
+                .setTitle(title)
+                .setView(input)
+                .setCancelable(false)
+                .setPositiveButton("OK") { _, _ ->
+                    cont.resume(input.text.toString()) {}
+                }
+                .setNegativeButton("Batal") { _, _ ->
+                    cont.resume("") {}
+                }
+                .show()
         }
     }
 }


### PR DESCRIPTION
## Summary
- support Instagram login using instagram4j
- handle two factor authentication and checkpoint challenges
- add instagram4j dependency

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1ec0be008327939aae2314155760