### PR TITLE
Implement Instagram profile display

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -4,9 +4,12 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ImageView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,10 +23,32 @@ import com.github.instagram4j.instagram4j.exceptions.IGLoginException
 import java.util.concurrent.Callable
 
 class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
+    private lateinit var loginContainer: View
+    private lateinit var profileContainer: View
+    private lateinit var avatarView: ImageView
+    private lateinit var usernameView: TextView
+    private lateinit var nameView: TextView
+    private lateinit var postsView: TextView
+    private lateinit var followersView: TextView
+    private lateinit var followingView: TextView
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val username = view.findViewById<EditText>(R.id.input_username)
         val password = view.findViewById<EditText>(R.id.input_password)
+        loginContainer = view.findViewById(R.id.login_container)
+        profileContainer = view.findViewById(R.id.profile_container)
+        avatarView = profileContainer.findViewById(R.id.image_avatar)
+        usernameView = profileContainer.findViewById(R.id.text_username)
+        nameView = profileContainer.findViewById(R.id.text_name)
+        postsView = profileContainer.findViewById(R.id.stat_posts)
+        followersView = profileContainer.findViewById(R.id.stat_followers)
+        followingView = profileContainer.findViewById(R.id.stat_following)
+
+        profileContainer.findViewById<Button>(R.id.button_logout).setOnClickListener {
+            profileContainer.visibility = View.GONE
+            loginContainer.visibility = View.VISIBLE
+        }
+
         view.findViewById<Button>(R.id.button_login_insta).setOnClickListener {
             val user = username.text.toString().trim()
             val pass = password.text.toString().trim()
@@ -49,14 +74,25 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
             }
 
             try {
-                IGClient.builder()
+                val client = IGClient.builder()
                     .username(user)
                     .password(pass)
                     .onTwoFactor(twoFactorHandler)
                     .onChallenge(challengeHandler)
                     .login()
+                val info = client.actions().users().info(client.selfProfile.pk).join()
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(requireContext(), "Login Instagram berhasil", Toast.LENGTH_SHORT).show()
+                    usernameView.text = "@${info.username}"
+                    nameView.text = info.full_name ?: ""
+                    postsView.text = info.media_count.toString()
+                    followersView.text = info.follower_count.toString()
+                    followingView.text = info.following_count.toString()
+                    Glide.with(this@InstaLoginFragment)
+                        .load(info.profile_pic_url)
+                        .circleCrop()
+                        .into(avatarView)
+                    loginContainer.visibility = View.GONE
+                    profileContainer.visibility = View.VISIBLE
                 }
             } catch (e: IGLoginException) {
                 withContext(Dispatchers.Main) {

--- a/app/src/main/res/layout/fragment_insta_login.xml
+++ b/app/src/main/res/layout/fragment_insta_login.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:padding="16dp"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/login_container"
+        android:orientation="vertical"
+        android:padding="16dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <EditText
         android:id="@+id/input_username"
@@ -19,10 +24,18 @@
         android:inputType="textPassword"
         android:layout_marginTop="8dp" />
 
-    <Button
-        android:id="@+id/button_login_insta"
+        <Button
+            android:id="@+id/button_login_insta"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Login"
+            android:layout_marginTop="16dp" />
+    </LinearLayout>
+
+    <include
+        android:id="@+id/profile_container"
+        layout="@layout/activity_profile"
+        android:visibility="gone"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Login"
-        android:layout_marginTop="16dp" />
-</LinearLayout>
+        android:layout_height="match_parent" />
+</FrameLayout>


### PR DESCRIPTION
## Summary
- enable `InstaLoginFragment` to hide the login form once authentication succeeds
- show the user's Instagram profile picture and statistics on success
- include the existing profile layout inside the Instagram login fragment

## Testing
- `xmllint --noout app/src/main/res/layout/fragment_insta_login.xml`
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_685e21ccbe088327a61590f65ebb4ba2