### PR TITLE
Hide NRP on Instagram profile

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -43,6 +43,8 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
         postsView = profileContainer.findViewById(R.id.stat_posts)
         followersView = profileContainer.findViewById(R.id.stat_followers)
         followingView = profileContainer.findViewById(R.id.stat_following)
+        profileContainer.findViewById<View>(R.id.text_nrp).visibility = View.GONE
+        profileContainer.findViewById<View>(R.id.info_container).visibility = View.GONE
 
         profileContainer.findViewById<Button>(R.id.button_logout).setOnClickListener {
             profileContainer.visibility = View.GONE


### PR DESCRIPTION
## Summary
- conceal NRP and backend info when showing the Instagram profile

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2bb4945c8327b3038e9075b538e1