### PR TITLE
Fix timeline feed parsing

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -127,9 +127,6 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                 val posts = client.actions().timeline().feed()
                     .stream()
                     .flatMap { it.feed_items.stream() }
-                    .map { it.media }
-                    .filter { it != null }
-                    .map { media -> media!! }
                     .limit(12)
                     .map { media ->
                         InstaPost(


### PR DESCRIPTION
## Summary
- correct timeline feed parsing logic by removing nonexistent `media` field references

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e32ac534c83278cd843208e8ddbff