### PR TITLE
Fix recent post image retrieval

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -129,10 +129,15 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                     .flatMap { it.feed_items.stream() }
                     .limit(12)
                     .map { media ->
+                        val imageUrl = (media as? com.github.instagram4j.instagram4j.models.media.ImageMedia)
+                            ?.image_versions2
+                            ?.candidates
+                            ?.firstOrNull()
+                            ?.url
                         InstaPost(
                             id = media.code,
                             caption = media.caption?.text,
-                            imageUrl = media.image_versions2?.candidates?.firstOrNull()?.url,
+                            imageUrl = imageUrl,
                             createdAt = java.time.Instant.ofEpochSecond(media.taken_at).toString()
                         )
                     }


### PR DESCRIPTION
## Summary
- cast timeline media to `ImageMedia` when fetching recent posts

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e348541408327bb9f2b78fae87325