### PR TITLE
Add Instagram session caching and new 2FA dialog

### DIFF
--- a/app/src/main/res/layout/dialog_two_factor.xml
+++ b/app/src/main/res/layout/dialog_two_factor.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/text_prompt"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Masukan Kode 2FA"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+    <EditText
+        android:id="@+id/edit_code"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="number"
+        android:layout_marginTop="12dp" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- keep IG session using serialized client/cookie files
- hide login form when a valid session exists
- redesign 2FA input dialog with numeric field and text `Masukan Kode 2FA`

## Testing
- `./gradlew assembleDebug --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e43c1ed3c832790eab673c67c7f9c