### PR TITLE
Fix like status access

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -289,7 +289,7 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                             com.github.instagram4j.instagram4j.requests.media.MediaInfoRequest(id)
                         ).join()
                     }
-                    alreadyLiked = info.items.firstOrNull()?.has_liked == true
+                    alreadyLiked = info.items.firstOrNull()?.isHas_liked == true
                     appendLog(
                         "> status: ${'$'}{if (alreadyLiked) "already liked" else "not yet liked"}",
                         animate = true


### PR DESCRIPTION
## Summary
- fix call to like status from Instagram4j

## Testing
- `./gradlew compileDebugKotlin --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eba61e55483279e90181d5de9c788