### PR TITLE
Fix unbound app namespace in layout

### DIFF
--- a/app/src/main/res/layout/activity_premium_registration.xml
+++ b/app/src/main/res/layout/activity_premium_registration.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp">


### PR DESCRIPTION
## Summary
- bind the `app` namespace in `activity_premium_registration.xml`

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7f0aa9e483279830544c13f56324