### PR TITLE
Add premium badge and disable username editing

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -57,7 +57,7 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
     private lateinit var loginContainer: View
     private lateinit var profileContainer: View
     private lateinit var startButton: Button
-    private lateinit var premiumStatusView: TextView
+    private lateinit var badgeView: ImageView
     private lateinit var logContainer: android.widget.LinearLayout
     private lateinit var logScroll: android.widget.ScrollView
     private lateinit var avatarView: ImageView
@@ -98,7 +98,7 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
         profileView.findViewById<Button>(R.id.button_logout).visibility = View.GONE
 
         startButton = view.findViewById(R.id.button_start)
-        premiumStatusView = view.findViewById(R.id.text_subscription_status)
+        badgeView = profileView.findViewById(R.id.image_badge)
         logContainer = view.findViewById(R.id.log_container)
         logScroll = view.findViewById(R.id.log_scroll)
 
@@ -238,12 +238,12 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                 client.newCall(req).execute().use { resp ->
                     isPremium = resp.isSuccessful
                     withContext(Dispatchers.Main) {
-                        premiumStatusView.text = if (isPremium) "Status: Premium" else "Status: Basic"
+                        badgeView.setImageResource(if (isPremium) R.drawable.ic_badge_premium else R.drawable.ic_badge_basic)
                     }
                 }
             } catch (_: Exception) {
                 withContext(Dispatchers.Main) {
-                    premiumStatusView.text = "Status: Basic"
+                    badgeView.setImageResource(R.drawable.ic_badge_basic)
                 }
             }
         }

--- a/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
@@ -29,6 +29,7 @@ class PremiumRegistrationActivity : AppCompatActivity() {
         intent.getStringExtra("username")?.takeIf { it.isNotBlank() }?.let {
             username.setText(it)
         }
+        username.isEnabled = false
         val nama = findViewById<EditText>(R.id.input_nama_rekening)
         val nomor = findViewById<EditText>(R.id.input_nomor_rekening)
         val phone = findViewById<EditText>(R.id.input_phone)

--- a/app/src/main/res/drawable/ic_badge_basic.xml
+++ b/app/src/main/res/drawable/ic_badge_basic.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#BDBDBD"
+        android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.64,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28L6,10.51l4.38,-0.38L12,6.1l1.62,4.03 4.38,0.38-3.24,2.88 1,4.28L12,15.4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_badge_premium.xml
+++ b/app/src/main/res/drawable/ic_badge_premium.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFC107"
+        android:pathData="M12,17.27L18.18,21l-1.64-7.03L22,9.24l-7.19-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -45,6 +45,16 @@
             app:layout_constraintEnd_toEndOf="@id/image_avatar"
             tools:ignore="ContentDescription,HardcodedText,ImageContrastCheck" />
 
+        <ImageView
+            android:id="@+id/image_badge"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_margin="4dp"
+            android:src="@drawable/ic_badge_basic"
+            android:contentDescription="@string/todo"
+            app:layout_constraintBottom_toBottomOf="@id/image_avatar"
+            app:layout_constraintEnd_toStartOf="@id/image_status" />
+
         <TextView
             android:id="@+id/text_username"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_insta_login.xml
+++ b/app/src/main/res/layout/fragment_insta_login.xml
@@ -45,14 +45,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <TextView
-            android:id="@+id/text_subscription_status"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Status: -"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="8dp" />
 
         <Button
             android:id="@+id/button_start"


### PR DESCRIPTION
## Summary
- disable editing of username during premium registration
- show a basic/premium badge beside the status icon
- remove text status from insta login layout
- add drawable resources for the badges

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f88246c7c8327a03955ed1b434859