### PR TITLE
Add subscription confirmation screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         <activity android:name=".DashboardActivity" />
         <activity android:name=".LoginActivity" />
         <activity android:name=".PremiumRegistrationActivity" />
+        <activity android:name=".SubscriptionConfirmActivity" />
         <activity
             android:name=".SplashActivity"
             android:exported="true">

--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -700,6 +700,12 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                 startActivity(intent)
                 true
             }
+            R.id.action_confirm_subscription -> {
+                val intent = android.content.Intent(requireContext(), SubscriptionConfirmActivity::class.java)
+                intent.putExtra("username", currentUsername ?: "")
+                startActivity(intent)
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
@@ -78,6 +78,9 @@ class PremiumRegistrationActivity : AppCompatActivity() {
                 withContext(Dispatchers.Main) {
                     if (success) {
                         Toast.makeText(this@PremiumRegistrationActivity, "Pendaftaran tersimpan", Toast.LENGTH_SHORT).show()
+                        val intent = android.content.Intent(this@PremiumRegistrationActivity, SubscriptionConfirmActivity::class.java)
+                        intent.putExtra("username", usernameVal)
+                        startActivity(intent)
                         finish()
                     } else {
                         Toast.makeText(this@PremiumRegistrationActivity, "Gagal mendaftar", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/cicero/repostapp/SubscriptionConfirmActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/SubscriptionConfirmActivity.kt
@@ -1,0 +1,58 @@
+package com.cicero.repostapp
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+class SubscriptionConfirmActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_subscription_confirm)
+
+        val confirmButton = findViewById<Button>(R.id.button_confirm)
+        val cancelButton = findViewById<Button>(R.id.button_cancel)
+
+        cancelButton.setOnClickListener { finish() }
+
+        confirmButton.setOnClickListener {
+            val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+            val token = prefs.getString("token", "") ?: ""
+            val username = intent.getStringExtra("username") ?: ""
+            if (token.isBlank() || username.isBlank()) {
+                Toast.makeText(this, "Anda belum login", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            CoroutineScope(Dispatchers.IO).launch {
+                val client = OkHttpClient()
+                val json = JSONObject().apply { put("username", username) }
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val req = Request.Builder()
+                    .url("https://papiqo.com/api/subscription-confirmations")
+                    .header("Authorization", "Bearer $token")
+                    .post(body)
+                    .build()
+                val success = try {
+                    client.newCall(req).execute().use { it.isSuccessful }
+                } catch (_: Exception) { false }
+                withContext(Dispatchers.Main) {
+                    if (success) {
+                        Toast.makeText(this@SubscriptionConfirmActivity, "Konfirmasi berhasil dikirim", Toast.LENGTH_SHORT).show()
+                        finish()
+                    } else {
+                        Toast.makeText(this@SubscriptionConfirmActivity, "Gagal mengirim konfirmasi", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_subscription_confirm.xml
+++ b/app/src/main/res/layout/activity_subscription_confirm.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/subscription_confirm_title"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/text_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/subscription_confirm_info"
+        android:layout_marginTop="8dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_confirm"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/confirm"
+        android:layout_marginTop="24dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_cancel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/cancel"
+        android:layout_marginTop="8dp" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_insta_profile.xml
+++ b/app/src/main/res/menu/menu_insta_profile.xml
@@ -9,4 +9,8 @@
         android:id="@+id/action_register_premium"
         android:title="Daftar Premium"
         android:showAsAction="never" />
+    <item
+        android:id="@+id/action_confirm_subscription"
+        android:title="@string/subscription_confirm_menu"
+        android:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,5 +24,9 @@
     <string name="premium_registration_title">Pendaftaran Premium</string>
     <string name="premium_registration_info">Isi data berikut lalu transfer sesuai nominal ke No.Rek BCA 0891758684 a.n Rizqa Febryan Prastyo.</string>
     <string name="session_end_format">Sesi berakhir pada: %1$s</string>
+    <string name="subscription_confirm_menu">Konfirmasi Pembayaran</string>
+    <string name="subscription_confirm_title">Konfirmasi Pembayaran</string>
+    <string name="subscription_confirm_info">Jika sudah melakukan transfer, tekan tombol di bawah untuk mengirim konfirmasi.</string>
+    <string name="confirm">Konfirmasi</string>
     <string name="cancel">Batal</string>
 </resources>


### PR DESCRIPTION
## Summary
- create a confirmation layout and activity
- trigger confirmation screen after premium registration
- add profile menu action for payment confirmation
- hook activity into manifest and strings

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe028664883279b5faf59307c7fe8