### PR TITLE
Improve Twitter login security

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,4 +61,5 @@ dependencies {
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("com.github.instagram4j:instagram4j:2.0.7")
     implementation("org.twitter4j:twitter4j-core:4.1.2")
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 }


### PR DESCRIPTION
## Summary
- secure tokens using `EncryptedSharedPreferences`
- run network calls in `lifecycleScope`
- avoid null-pointer crashes during login
- add Jetpack Security Crypto dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615eb82e608327b2bc06719d818ac0