### PR TITLE
Improve error logging

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -10,6 +10,7 @@ import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import com.bumptech.glide.Glide
@@ -174,8 +175,10 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                     Toast.makeText(requireContext(), "Gagal login: ${e.loginResponse.message}", Toast.LENGTH_SHORT).show()
                 }
             } catch (e: Exception) {
+                Log.e("InstaLoginFragment", "Login failed", e)
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(requireContext(), "Error: ${e.localizedMessage}", Toast.LENGTH_SHORT).show()
+                    val message = e.message ?: e.toString()
+                    Toast.makeText(requireContext(), "Error: $message", Toast.LENGTH_SHORT).show()
                 }
             }
         }

--- a/app/src/main/java/com/cicero/repostapp/TwitterFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterFragment.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
@@ -103,8 +104,10 @@ class TwitterFragment : Fragment(R.layout.fragment_twitter) {
                     statusView.text = getString(R.string.enter_pin)
                 }
             } catch (e: Exception) {
+                Log.e("TwitterFragment", "Error starting login", e)
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(requireContext(), "${'$'}{e.localizedMessage}", Toast.LENGTH_SHORT).show()
+                    val msg = e.message ?: e.toString()
+                    Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
                 }
             }
         }
@@ -138,7 +141,8 @@ class TwitterFragment : Fragment(R.layout.fragment_twitter) {
                     }
                     Toast.makeText(requireContext(), "Login berhasil", Toast.LENGTH_SHORT).show()
                 }
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.e("TwitterFragment", "Error finishing login", e)
                 withContext(Dispatchers.Main) {
                     Toast.makeText(requireContext(), "PIN salah", Toast.LENGTH_SHORT).show()
                 }


### PR DESCRIPTION
## Summary
- show real error messages in InstaLoginFragment
- show real error messages in TwitterFragment

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620c2d3acc8327abc330956e2c1cd5