### PR TITLE
Reorder bottom navigation

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
@@ -20,8 +20,8 @@ class DashboardActivity : AppCompatActivity() {
 
         val fragments = listOf(
             UserProfileFragment.newInstance(userId, token),
-            InstaLoginFragment(),
             DashboardFragment.newInstance(userId, token),
+            InstaLoginFragment(),
             TwitterFragment(),
             TiktokFragment()
         )
@@ -37,8 +37,8 @@ class DashboardActivity : AppCompatActivity() {
         bottomNav.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.nav_profile -> { viewPager.currentItem = 0; true }
-                R.id.nav_insta_login -> { viewPager.currentItem = 1; true }
-                R.id.nav_insta -> { viewPager.currentItem = 2; true }
+                R.id.nav_insta -> { viewPager.currentItem = 1; true }
+                R.id.nav_insta_login -> { viewPager.currentItem = 2; true }
                 R.id.nav_twitter -> { viewPager.currentItem = 3; true }
                 R.id.nav_tiktok -> { viewPager.currentItem = 4; true }
                 else -> false
@@ -49,14 +49,14 @@ class DashboardActivity : AppCompatActivity() {
             override fun onPageSelected(position: Int) {
                 when (position) {
                     0 -> bottomNav.selectedItemId = R.id.nav_profile
-                    1 -> bottomNav.selectedItemId = R.id.nav_insta_login
-                    2 -> bottomNav.selectedItemId = R.id.nav_insta
+                    1 -> bottomNav.selectedItemId = R.id.nav_insta
+                    2 -> bottomNav.selectedItemId = R.id.nav_insta_login
                     3 -> bottomNav.selectedItemId = R.id.nav_twitter
                     4 -> bottomNav.selectedItemId = R.id.nav_tiktok
                 }
             }
         })
 
-        viewPager.currentItem = 2
+        viewPager.currentItem = 1
     }
 }

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -5,13 +5,13 @@
         android:icon="@android:drawable/ic_menu_myplaces"
         android:title="Profil" />
     <item
-        android:id="@+id/nav_insta_login"
-        android:icon="@android:drawable/ic_menu_edit"
-        android:title="Insta" />
-    <item
         android:id="@+id/nav_insta"
         android:icon="@android:drawable/ic_menu_gallery"
         android:title="Konten" />
+    <item
+        android:id="@+id/nav_insta_login"
+        android:icon="@android:drawable/ic_menu_edit"
+        android:title="Insta" />
     <item
         android:id="@+id/nav_twitter"
         android:icon="@android:drawable/ic_menu_share"


### PR DESCRIPTION
## Summary
- move `nav_insta` menu item between profile and insta login
- rearrange fragments in `DashboardActivity`
- update navigation callbacks

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862344b5da88327a5dbde7efa6a0a70