### PR TITLE
Fix Tiktok login toast string

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -873,7 +873,7 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                         val user = TikwmApi.fetchUser(username)
                         if (user != null) {
                             TiktokSessionManager.saveProfile(requireContext(), user)
-                            Toast.makeText(requireContext(), "Logged in as ${'$'}{user.optString("uniqueId")}", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(requireContext(), "Logged in as ${user.optString("uniqueId")}", Toast.LENGTH_SHORT).show()
                         } else {
                             Toast.makeText(requireContext(), "Login gagal", Toast.LENGTH_SHORT).show()
                         }


### PR DESCRIPTION
## Summary
- correct toast message interpolation when logging in with TikTok

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625f5244ec8327a8f2585bf7fe0d88