### PR TITLE
Add Facebook fragment

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
@@ -4,8 +4,8 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.cicero.repostapp.FacebookFragment
 
 class DashboardActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,6 +23,7 @@ class DashboardActivity : AppCompatActivity() {
             DashboardFragment.newInstance(userId, token),
             InstaLoginFragment(),
             TwitterFragment(),
+            FacebookFragment(),
             TiktokFragment()
         )
 
@@ -40,7 +41,8 @@ class DashboardActivity : AppCompatActivity() {
                 R.id.nav_insta -> { viewPager.currentItem = 1; true }
                 R.id.nav_insta_login -> { viewPager.currentItem = 2; true }
                 R.id.nav_twitter -> { viewPager.currentItem = 3; true }
-                R.id.nav_tiktok -> { viewPager.currentItem = 4; true }
+                R.id.nav_facebook -> { viewPager.currentItem = 4; true }
+                R.id.nav_tiktok -> { viewPager.currentItem = 5; true }
                 else -> false
             }
         }
@@ -52,7 +54,8 @@ class DashboardActivity : AppCompatActivity() {
                     1 -> bottomNav.selectedItemId = R.id.nav_insta
                     2 -> bottomNav.selectedItemId = R.id.nav_insta_login
                     3 -> bottomNav.selectedItemId = R.id.nav_twitter
-                    4 -> bottomNav.selectedItemId = R.id.nav_tiktok
+                    4 -> bottomNav.selectedItemId = R.id.nav_facebook
+                    5 -> bottomNav.selectedItemId = R.id.nav_tiktok
                 }
             }
         })

--- a/app/src/main/java/com/cicero/repostapp/FacebookFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/FacebookFragment.kt
@@ -1,0 +1,15 @@
+package com.cicero.repostapp
+
+import android.os.Bundle
+import android.view.View
+import android.webkit.WebView
+import androidx.fragment.app.Fragment
+
+class FacebookFragment : Fragment(R.layout.fragment_facebook) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val webView: WebView = view.findViewById(R.id.web_facebook)
+        webView.settings.javaScriptEnabled = true
+        webView.loadUrl("https://m.facebook.com/")
+    }
+}

--- a/app/src/main/res/layout/fragment_facebook.xml
+++ b/app/src/main/res/layout/fragment_facebook.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WebView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/web_facebook"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -17,6 +17,10 @@
         android:icon="@android:drawable/ic_menu_share"
         android:title="Twitter" />
     <item
+        android:id="@+id/nav_facebook"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="@string/facebook" />
+    <item
         android:id="@+id/nav_tiktok"
         android:icon="@android:drawable/ic_menu_slideshow"
         android:title="TikTok" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,5 @@
     <string name="verify_pin">Verifikasi PIN</string>
     <string name="enter_pin">Masukkan PIN</string>
     <string name="not_logged_in">Belum login</string>
+    <string name="facebook">Facebook</string>
 </resources>


### PR DESCRIPTION
## Summary
- create `FacebookFragment` with a WebView
- add new layout for the fragment
- expand bottom navigation with a Facebook item
- include fragment in `DashboardActivity`
- add string resource

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862647dfa888327a32f611b30189d95