### PR TITLE
Show Twitter auth response

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/TwitterCallbackActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterCallbackActivity.kt
@@ -17,11 +17,11 @@ class TwitterCallbackActivity : AppCompatActivity() {
             return
         }
         lifecycleScope.launch(Dispatchers.IO) {
-            val success = TwitterAuthManager.finishAuth(this@TwitterCallbackActivity, verifier)
+            val result = TwitterAuthManager.finishAuth(this@TwitterCallbackActivity, verifier)
             withContext(Dispatchers.Main) {
                 Toast.makeText(
                     this@TwitterCallbackActivity,
-                    if (success) "Login berhasil" else "Login gagal",
+                    result,
                     Toast.LENGTH_SHORT
                 ).show()
                 finish()

--- a/app/src/main/res/layout/fragment_twitter.xml
+++ b/app/src/main/res/layout/fragment_twitter.xml
@@ -44,5 +44,12 @@
             android:layout_marginTop="8dp"
             android:visibility="gone" />
 
+        <TextView
+            android:id="@+id/text_twitter_response"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:textIsSelectable="true" />
+
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
## Summary
- display the latest Twitter auth response in `TwitterFragment`
- store last auth result in `TwitterAuthManager`
- report login result via `TwitterCallbackActivity`
- add a TextView to show the response in the Twitter layout

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ac1d47288327a4ac3df325a20eae