### PR TITLE
Move social icons above options

### DIFF
--- a/app/src/main/res/layout/fragment_insta_login.xml
+++ b/app/src/main/res/layout/fragment_insta_login.xml
@@ -90,39 +90,6 @@
             android:layout_height="wrap_content" />
 
         <LinearLayout
-            android:id="@+id/options_container"
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            android:layout_marginTop="8dp">
-
-            <CheckBox
-                android:id="@+id/checkbox_like"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Likes"
-                android:checked="true" />
-
-            <CheckBox
-                android:id="@+id/checkbox_repost"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Repost"
-                android:checked="true"
-                android:layout_marginStart="16dp" />
-
-            <CheckBox
-                android:id="@+id/checkbox_comment"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Komentar"
-                android:checked="true"
-                android:layout_marginStart="16dp" />
-        </LinearLayout>
-
-        <LinearLayout
             android:id="@+id/social_icons_row"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -193,6 +160,39 @@
                 android:src="@drawable/yt_icon"
                 android:contentDescription="YouTube" />
 
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/options_container"
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:layout_marginTop="8dp">
+
+            <CheckBox
+                android:id="@+id/checkbox_like"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Likes"
+                android:checked="true" />
+
+            <CheckBox
+                android:id="@+id/checkbox_repost"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Repost"
+                android:checked="true"
+                android:layout_marginStart="16dp" />
+
+            <CheckBox
+                android:id="@+id/checkbox_comment"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Komentar"
+                android:checked="true"
+                android:layout_marginStart="16dp" />
         </LinearLayout>
 
         <Button


### PR DESCRIPTION
## Summary
- reorder Insta login layout so the social media icons row appears above the action checkboxes

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_68632ba651b08327a61819fb9d8fd64d