### PR TITLE
Fix twitter username display in Insta page

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstaLoginFragment.kt
@@ -325,7 +325,7 @@ class InstaLoginFragment : Fragment(R.layout.fragment_insta_login) {
                 try {
                     val user = tw.verifyCredentials()
                     withContext(Dispatchers.Main) {
-                        twitterUsernameView.text = "@${'$'}{user.screenName}"
+                        twitterUsernameView.text = "@${user.screenName}"
                         twitterUsernameView.visibility = View.VISIBLE
                         Glide.with(this@InstaLoginFragment)
                             .load(user.profileImageURLHttps)


### PR DESCRIPTION
## Summary
- correct kotlin string interpolation for twitter username display under the Twitter icon

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632e3074dc8327a4d3dc8a6a4bfbaf