### PR TITLE
Update Facebook login to use m.facebook.com

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/FacebookFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/FacebookFragment.kt
@@ -33,7 +33,7 @@ class FacebookFragment : Fragment(R.layout.fragment_facebook) {
         val saved = FacebookSessionManager.loadCookies(requireContext())
         if (saved != null) {
             cookieManager.setCookie("https://facebook.com", saved)
-            cookieManager.setCookie("https://basic.facebook.com", saved)
+            cookieManager.setCookie("https://m.facebook.com", saved)
             cookieManager.flush()
             loginButton.text = getString(R.string.logout)
             loginButton.setOnClickListener { logout(statusView, loginButton, cookieManager) }
@@ -75,7 +75,7 @@ class FacebookFragment : Fragment(R.layout.fragment_facebook) {
 
             override fun onPageFinished(view: WebView?, url: String?) {
                 progressBar.visibility = View.GONE
-                val cookies = manager.getCookie("https://basic.facebook.com")
+                val cookies = manager.getCookie("https://m.facebook.com")
                 val loggedIn = !cookies.isNullOrBlank() && cookies.contains("c_user=")
                 if (loggedIn && url != null && url.contains("/me")) {
                     FacebookSessionManager.saveCookies(requireContext(), cookies)
@@ -98,7 +98,7 @@ class FacebookFragment : Fragment(R.layout.fragment_facebook) {
                 Toast.makeText(requireContext(), error?.description ?: error.toString(), Toast.LENGTH_SHORT).show()
             }
         }
-        webView.loadUrl("https://basic.facebook.com/login.php?next=https%3A%2F%2Fbasic.facebook.com%2Fme")
+        webView.loadUrl("https://m.facebook.com/login.php?next=https%3A%2F%2Fm.facebook.com%2Fme")
     }
 
     private fun fetchProfile(statusView: TextView) {
@@ -107,7 +107,7 @@ class FacebookFragment : Fragment(R.layout.fragment_facebook) {
                 val cookies = FacebookSessionManager.loadCookies(requireContext()) ?: return@launch
                 val client = OkHttpClient()
                 val req = Request.Builder()
-                    .url("https://basic.facebook.com/me")
+                    .url("https://m.facebook.com/me")
                     .header("Cookie", cookies)
                     .header("User-Agent", "Mozilla/5.0 (Android)")
                     .build()

--- a/docs/FACEBOOK_LOGIN.md
+++ b/docs/FACEBOOK_LOGIN.md
@@ -3,7 +3,7 @@
 This fragment shows how the application logs a user into Facebook using a built-in WebView.
 
 1. When the **Login dengan Facebook** button is pressed the WebView is displayed.
-2. The login page from `basic.facebook.com` is loaded and a progress bar is shown.
+2. The login page from `m.facebook.com` is loaded and a progress bar is shown.
 3. After credentials are entered and the page redirects to `/me`, cookies are stored securely using `FacebookSessionManager`.
 4. The fragment then fetches the profile title from `/me` to display the logged in name.
 5. Pressing **Logout** removes the cookies and shows the login button again.


### PR DESCRIPTION
## Summary
- switch Facebook login URLs from basic.facebook.com to m.facebook.com
- update docs accordingly

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `npm test` *(fails: missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6863393beee4832790c6f881d6f201a7