### PR TITLE
Improve Facebook profile check

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/FacebookFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/FacebookFragment.kt
@@ -22,17 +22,32 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 
 class FacebookFragment : Fragment(R.layout.fragment_facebook) {
+    private lateinit var statusView: TextView
+    private lateinit var avatarView: ImageView
+    private lateinit var loginButton: MaterialButton
+    private lateinit var webView: WebView
+    private lateinit var progressBar: ProgressBar
+    private val cookieManager: CookieManager = CookieManager.getInstance()
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val statusView: TextView = view.findViewById(R.id.text_facebook_status)
-        val avatarView: ImageView = view.findViewById(R.id.image_facebook_avatar)
-        val loginButton: MaterialButton = view.findViewById(R.id.button_facebook_login)
-        val webView: WebView = view.findViewById(R.id.webview_facebook)
-        val progressBar: ProgressBar = view.findViewById(R.id.progress_facebook)
-        val cookieManager = CookieManager.getInstance()
+        statusView = view.findViewById(R.id.text_facebook_status)
+        avatarView = view.findViewById(R.id.image_facebook_avatar)
+        loginButton = view.findViewById(R.id.button_facebook_login)
+        webView = view.findViewById(R.id.webview_facebook)
+        progressBar = view.findViewById(R.id.progress_facebook)
         cookieManager.setAcceptCookie(true)
 
+        refreshStatus()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshStatus()
+    }
+
+    private fun refreshStatus() {
         val saved = FacebookSessionManager.loadCookies(requireContext())
         if (saved != null) {
             cookieManager.setCookie("https://facebook.com", saved)
@@ -42,7 +57,12 @@ class FacebookFragment : Fragment(R.layout.fragment_facebook) {
             loginButton.setOnClickListener { logout(statusView, loginButton, cookieManager) }
             fetchProfile(statusView, avatarView)
         } else {
-            loginButton.setOnClickListener { startLogin(webView, progressBar, statusView, avatarView, loginButton, cookieManager) }
+            statusView.text = getString(R.string.not_logged_in)
+            avatarView.visibility = View.GONE
+            loginButton.text = getString(R.string.login_facebook)
+            loginButton.setOnClickListener {
+                startLogin(webView, progressBar, statusView, avatarView, loginButton, cookieManager)
+            }
         }
     }
 

--- a/docs/FACEBOOK_LOGIN.md
+++ b/docs/FACEBOOK_LOGIN.md
@@ -6,4 +6,5 @@ This fragment shows how the application logs a user into Facebook using a built-
 2. The login page from `m.facebook.com` is loaded and a progress bar is shown.
 3. After credentials are entered and the page redirects to `/me`, cookies are stored securely using `FacebookSessionManager`.
 4. The fragment fetches the `/me` page again to read the title and profile image. The user's name and avatar are displayed when the session is active.
-5. Pressing **Logout** removes the cookies and hides the profile picture while showing the login button again.
+5. Whenever the fragment resumes it checks saved cookies and updates the profile view, so returning users immediately see their information.
+6. Pressing **Logout** removes the cookies and hides the profile picture while showing the login button again.


### PR DESCRIPTION
## Summary
- refresh the Facebook login status when the fragment resumes
- clarify Facebook login documentation

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863711c00cc83279ce10b43c5b1916b