### PR TITLE
Update Facebook profile icon in IG tools

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/InstagramToolsFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/InstagramToolsFragment.kt
@@ -425,7 +425,13 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     client.newCall(req).execute().use { resp ->
                         val body = resp.body?.string().orEmpty()
                         val name = Regex("<title>([^<]+)").find(body)?.groupValues?.get(1)
-                        val picUrl = Regex("src=\"([^\"]+profile[^\"]*)\"").find(body)?.groupValues?.get(1)
+                        val picUrl =
+                            Regex("<img[^>]+src=\\\"([^\\\"]+)\\\"[^>]*profile", RegexOption.IGNORE_CASE)
+                                .find(body)?.groupValues?.get(1)
+                                ?: Regex(
+                                    "profilePicThumb\\\"[^>]*src=\\\"([^\\\"]+)\\\"",
+                                    RegexOption.IGNORE_CASE
+                                ).find(body)?.groupValues?.get(1)
                         withContext(Dispatchers.Main) {
                             if (!name.isNullOrBlank()) {
                                 facebookUsernameView.text = name


### PR DESCRIPTION
## Summary
- fetch user picture with a more reliable regex when Facebook session is active
- update the Facebook icon with the profile picture on the Instagram tools page

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686374e714e88327ae61b20c0bb0ef82