### PR TITLE
Add IG Tools Facebook session scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ found in the [docs](docs/) directory:
 - [`USAGE.md`](docs/USAGE.md) – how to build and interact with the app.
 - [`landing_page.html`](docs/landing_page.html) – a lightweight landing page
   describing key features and providing a download link.
+- [`IGTOOLS_FACEBOOK.md`](docs/IGTOOLS_FACEBOOK.md) – skenario pemuatan profil
+  Facebook di halaman IG Tools.
 
 ## TikTok Automation
 

--- a/docs/IGTOOLS_FACEBOOK.md
+++ b/docs/IGTOOLS_FACEBOOK.md
@@ -1,0 +1,21 @@
+# Integrasi Facebook di Halaman IG Tools
+
+Dokumen ini menjelaskan alur memuat foto profil dan nama akun Facebook di halaman **Instagram Tools** apabila sesi login masih ada.
+
+## 1. Pengecekan Sesi
+
+Saat `InstagramToolsFragment` dibuat atau kembali aktif, fungsi `updateFacebookStatus()` dijalankan. Fungsi ini memanggil `FacebookSessionManager.loadCookies()` untuk membaca cookie yang tersimpan secara terenkripsi. Jika cookie ditemukan, fragment akan mencoba mengambil halaman `https://m.facebook.com/me` menggunakan OkHttp.
+
+## 2. Mendapatkan Nama dan Foto Profil
+
+Respon HTML dari `/me` dipindai menggunakan regex untuk mencari tag `<title>` sebagai nama pengguna dan URL gambar profil. Nilai tersebut lalu ditampilkan pada `image_facebook` dan `text_facebook_username`.
+
+## 3. Proses Login
+
+Bila belum ada cookie, pengguna dapat menekan ikon Facebook pada halaman IG Tools. Hal ini membuka `FacebookLoginActivity` yang menampilkan WebView login dari `m.facebook.com`. Setelah kredensial valid dan halaman mengarah ke `/me`, cookie disimpan lewat `FacebookSessionManager.saveCookies()` dan activity ditutup.
+
+## 4. Penyimpanan Sesi
+
+Cookie disimpan di `EncryptedSharedPreferences` sehingga tetap aman dan dapat digunakan kembali ketika aplikasi dibuka ulang. Setiap kali `InstagramToolsFragment` muncul, cookie ini otomatis dipasang ke `CookieManager` sehingga status login tidak hilang.
+
+Dengan alur ini, halaman IG Tools dapat langsung menampilkan nama dan foto profil Facebook tanpa login ulang selama cookie masih valid.


### PR DESCRIPTION
## Summary
- document how the IG Tools page loads Facebook profile info when a session exists
- link the new doc from README

## Testing
- `./gradlew tasks`

------
https://chatgpt.com/codex/tasks/task_e_6863bff6c2288327b3d712c982d470da