### PR TITLE
Fix YouTube login failure message

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/YoutubeFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/YoutubeFragment.kt
@@ -39,6 +39,7 @@ class YoutubeFragment : Fragment(R.layout.fragment_youtube) {
             onSignedIn(account)
         } catch (e: Exception) {
             statusView.text = getString(R.string.login_failed)
+            resultView.text = e.localizedMessage ?: e.toString()
         }
     }
 


### PR DESCRIPTION
## Summary
- show error details in YoutubeFragment when sign-in fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863d21f18288327999e058cc6ff75aa