### PR TITLE
Resolve Facebook provider manifest conflict

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="com.cicero.repostapp"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
@@ -25,7 +26,8 @@
         <provider
             android:name="com.facebook.internal.FacebookInitProvider"
             android:authorities="com.facebook.app.FacebookContentProvider${applicationId}"
-            android:exported="false" />
+            android:exported="false"
+            tools:replace="android:authorities" />
         <activity
             android:name=".TwitterCallbackActivity"
             android:exported="true">


### PR DESCRIPTION
## Summary
- add `tools` namespace to manifest
- override `FacebookInitProvider` authorities per Gradle merge suggestion

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e5920e788327b59a3bb872d0b411