### PR TITLE
Fix Facebook SDK init

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher_foreground"

--- a/app/src/main/java/com/cicero/repostapp/App.kt
+++ b/app/src/main/java/com/cicero/repostapp/App.kt
@@ -1,0 +1,11 @@
+package com.cicero.repostapp
+
+import android.app.Application
+import com.facebook.FacebookSdk
+
+class App : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        FacebookSdk.sdkInitialize(applicationContext)
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Facebook SDK on startup via Application class
- register the new Application class in the manifest

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_6864e8ca77c483278b71c9f58f35130b