### PR TITLE
Include user info in WhatsApp reports

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -456,7 +456,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         val satfung = prefsAuth.getString("satfung", "") ?: ""
         val nrp = prefsAuth.getString("userId", userId) ?: userId
         val userInfo = """
-            Tambahkan data nama : $rank $name
+            Nama : $rank $name
             NRP / NIP : $nrp
             Satfung : $satfung
         """.trimIndent()
@@ -473,9 +473,11 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
             https://instagram.com/p/$shortcode
 
             Laporan Link Pelaksanaan Sebagai Berikut :
-            1. ${links["instagram"] ?: "-"},
-            2. ${links["twitter"] ?: "-"},
-            3. ${links["tiktok"] ?: "-"}
+            1. ${links["instagram"] ?: "Nihil"},
+            2. ${links["facebook"] ?: "Nihil"},
+            3. ${links["twitter"] ?: "Nihil"},
+            4. ${links["tiktok"] ?: "Nihil"},
+            5. ${links["youtube"] ?: "Nihil"}
         """.trimIndent()
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -450,11 +450,24 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         val today = java.time.LocalDate.now()
         val day = today.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale))
         val dateStr = today.format(java.time.format.DateTimeFormatter.ofPattern("dd MMMM yyyy", locale))
+        val prefsAuth = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val rank = prefsAuth.getString("rank", "") ?: ""
+        val name = prefsAuth.getString("name", "") ?: ""
+        val satfung = prefsAuth.getString("satfung", "") ?: ""
+        val nrp = prefsAuth.getString("userId", userId) ?: userId
+        val userInfo = """
+            Tambahkan data nama : $rank $name
+            NRP / NIP : $nrp
+            Satfung : $satfung
+        """.trimIndent()
+
         val message = """
             Mohon ijin, Mengirimkan Laporan repost konten,
 
             Hari : $day,
             Tanggal : $dateStr
+
+            $userInfo
 
             dari Source Link Konten Instagram berikut :
             https://instagram.com/p/$shortcode
@@ -462,9 +475,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
             Laporan Link Pelaksanaan Sebagai Berikut :
             1. ${links["instagram"] ?: "-"},
             2. ${links["twitter"] ?: "-"},
-            3. ${links["tiktok"] ?: "-"},
-            
-            DUMM.
+            3. ${links["tiktok"] ?: "-"}
         """.trimIndent()
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -355,7 +355,7 @@ class ReportActivity : AppCompatActivity() {
         val satfung = prefsAuth.getString("satfung", "") ?: ""
         val nrp = prefsAuth.getString("userId", userId) ?: userId
         val userInfo = """
-            Tambahkan data nama : $rank $name
+            Nama : $rank $name
             NRP / NIP : $nrp
             Satfung : $satfung
         """.trimIndent()
@@ -372,11 +372,11 @@ class ReportActivity : AppCompatActivity() {
             https://instagram.com/p/$shortcode
 
             Laporan Link Pelaksanaan Sebagai Berikut :
-            1. ${links["instagram"] ?: "-"},
-            2. ${links["facebook"] ?: "-"},
-            3. ${links["twitter"] ?: "-"},
-            4. ${links["tiktok"] ?: "-"},
-            5. ${links["youtube"] ?: "-"}
+            1. ${links["instagram"] ?: "Nihil"},
+            2. ${links["facebook"] ?: "Nihil"},
+            3. ${links["twitter"] ?: "Nihil"},
+            4. ${links["tiktok"] ?: "Nihil"},
+            5. ${links["youtube"] ?: "Nihil"}
         """.trimIndent()
         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
             type = "text/plain"

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -349,11 +349,24 @@ class ReportActivity : AppCompatActivity() {
         val today = java.time.LocalDate.now()
         val day = today.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale))
         val dateStr = today.format(java.time.format.DateTimeFormatter.ofPattern("dd MMMM yyyy", locale))
+        val prefsAuth = getSharedPreferences("auth", MODE_PRIVATE)
+        val rank = prefsAuth.getString("rank", "") ?: ""
+        val name = prefsAuth.getString("name", "") ?: ""
+        val satfung = prefsAuth.getString("satfung", "") ?: ""
+        val nrp = prefsAuth.getString("userId", userId) ?: userId
+        val userInfo = """
+            Tambahkan data nama : $rank $name
+            NRP / NIP : $nrp
+            Satfung : $satfung
+        """.trimIndent()
+
         val message = """
             Mohon ijin, Mengirimkan Laporan repost konten,
 
             Hari : $day,
             Tanggal : $dateStr
+
+            $userInfo
 
             dari Source Link Konten Instagram berikut :
             https://instagram.com/p/$shortcode
@@ -363,9 +376,7 @@ class ReportActivity : AppCompatActivity() {
             2. ${links["facebook"] ?: "-"},
             3. ${links["twitter"] ?: "-"},
             4. ${links["tiktok"] ?: "-"},
-            5. ${links["youtube"] ?: "-"},
-
-            DUMM.
+            5. ${links["youtube"] ?: "-"}
         """.trimIndent()
         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
             type = "text/plain"

--- a/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
@@ -70,16 +70,28 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
                                 null
                             }
                             val insta = data?.optString("insta") ?: ""
+                            val rank = data?.optString("title") ?: ""
+                            val name = data?.optString("nama") ?: ""
+                            val satfung = data?.optString("divisi") ?: ""
+                            val nrp = data?.optString("user_id") ?: userId
+
+                            val authPrefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+                            authPrefs.edit()
+                                .putString("rank", rank)
+                                .putString("name", name)
+                                .putString("satfung", satfung)
+                                .apply()
+
                             rootView.findViewById<TextView>(R.id.text_username).text =
                                 "@$insta"
                             rootView.findViewById<TextView>(R.id.text_name).text =
-                                (data?.optString("title") ?: "") + " " + (data?.optString("nama") ?: "")
+                                "$rank $name"
                             rootView.findViewById<TextView>(R.id.text_nrp).text =
-                                (data?.optString("user_id") ?: userId)
+                                nrp
                             rootView.findViewById<TextView>(R.id.text_client_id).text =
                                 (data?.optString("client_id") ?: "")
                             rootView.findViewById<TextView>(R.id.text_satfung).text =
-                                (data?.optString("divisi") ?: "")
+                                satfung
                             rootView.findViewById<TextView>(R.id.text_jabatan).text =
                                 (data?.optString("jabatan") ?: "")
                             rootView.findViewById<TextView>(R.id.text_tiktok).text =


### PR DESCRIPTION
## Summary
- keep user profile info in SharedPreferences
- include rank, name, NRP and Satfung when composing WhatsApp messages

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_686e0a76e8648327aee98cec53693e65