### PR TITLE
Fix missing Facebook and YouTube links in report sharing

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -433,8 +433,10 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                     if (o.optString("shortcode") == sc && o.optString("user_id") == userId) {
                         return mapOf(
                             "instagram" to o.optString("instagram_link").takeIf { it.isNotBlank() },
+                            "facebook" to o.optString("facebook_link").takeIf { it.isNotBlank() },
                             "twitter" to o.optString("twitter_link").takeIf { it.isNotBlank() },
-                            "tiktok" to o.optString("tiktok_link").takeIf { it.isNotBlank() }
+                            "tiktok" to o.optString("tiktok_link").takeIf { it.isNotBlank() },
+                            "youtube" to o.optString("youtube_link").takeIf { it.isNotBlank() }
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- include facebook_link and youtube_link when retrieving reports in DashboardFragment

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e14218f7c8327837a65e843367179