### PR TITLE
Fix update check when tag has 'v' prefix

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/MainActivity.kt
@@ -84,7 +84,7 @@ class MainActivity : AppCompatActivity() {
                     val body = resp.body?.string()
                     if (resp.isSuccessful && body != null) {
                         val json = JSONObject(body)
-                        val tag = json.getString("tag_name")
+                        val tag = json.getString("tag_name").removePrefix("v")
                         if (tag != BuildConfig.VERSION_NAME) {
                             val assets = json.getJSONArray("assets")
                             if (assets.length() > 0) {


### PR DESCRIPTION
## Summary
- ensure update check ignores a leading 'v' in tag names

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687248eaccfc832783697ee36046496f