### PR TITLE
Fix BuildConfig import

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/MainActivity.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
+import com.cicero.repostapp.BuildConfig
 
 class MainActivity : AppCompatActivity() {
 


### PR DESCRIPTION
## Summary
- resolve unresolved reference to `BuildConfig` by importing the generated BuildConfig class in `MainActivity`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724bb4d2948327b0625206283f9152