### PR TITLE
Implement share chooser automation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,5 +47,16 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/instagram_service_config" />
         </service>
+        <service
+            android:name=".service.ShareChooserService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/share_chooser_service_config" />
+        </service>
     </application>
 </manifest>

--- a/app/src/main/java/com/cicero/repostapp/service/ShareChooserService.kt
+++ b/app/src/main/java/com/cicero/repostapp/service/ShareChooserService.kt
@@ -1,0 +1,77 @@
+package com.cicero.repostapp.service
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+
+class ShareChooserService : AccessibilityService() {
+
+    override fun onServiceConnected() {
+        serviceInfo = AccessibilityServiceInfo().apply {
+            eventTypes = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED or
+                    AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+            feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+        }
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        val root = rootInActiveWindow ?: return
+        if (containsText(root, listOf("Bagikan", "Share"))) {
+            checkRememberChoice(root)
+            clickInstagramFeed(root)
+        }
+    }
+
+    private fun containsText(node: AccessibilityNodeInfo?, keywords: List<String>): Boolean {
+        if (node == null) return false
+        for (k in keywords) {
+            if (node.text?.toString()?.contains(k, true) == true) return true
+            if (node.contentDescription?.toString()?.contains(k, true) == true) return true
+        }
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i)
+            if (containsText(child, keywords)) return true
+        }
+        return false
+    }
+
+    private fun findNodeByText(node: AccessibilityNodeInfo?, keywords: List<String>): AccessibilityNodeInfo? {
+        if (node == null) return null
+        for (k in keywords) {
+            if (node.text?.toString()?.contains(k, true) == true ||
+                node.contentDescription?.toString()?.contains(k, true) == true) {
+                return node
+            }
+        }
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i)
+            val res = findNodeByText(child, keywords)
+            if (res != null) return res
+        }
+        return null
+    }
+
+    private fun checkRememberChoice(root: AccessibilityNodeInfo) {
+        val node = findNodeByText(root, listOf("Ingat pilihan saya", "Remember my choice"))
+        var target = node
+        while (target != null && !target.isCheckable && !target.isClickable) {
+            target = target.parent
+        }
+        if (target != null && !target.isChecked) {
+            target.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        }
+    }
+
+    private fun clickInstagramFeed(root: AccessibilityNodeInfo) {
+        val node = findNodeByText(root, listOf("Instagram", "Feed")) ?: return
+        var target: AccessibilityNodeInfo? = node
+        while (target != null && !target.isClickable) {
+            target = target.parent
+        }
+        target?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+    }
+
+    override fun onInterrupt() {}
+}
+

--- a/app/src/main/res/xml/share_chooser_service_config.xml
+++ b/app/src/main/res/xml/share_chooser_service_config.xml
@@ -1,0 +1,5 @@
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:canRetrieveWindowContent="true"
+    android:description="@string/instagram_service_description"/>


### PR DESCRIPTION
## Summary
- add ShareChooserService accessibility service to automate selecting Instagram Feed
- register the new service in AndroidManifest
- ensure new accessibility services are enabled before autopost
- modify sharing flow to use intent chooser

## Testing
- `./gradlew test` *(fails: process did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_6872570da5908327b18699f24a0d19d9