### PR TITLE
Limit accessibility service to Instagram UI

### DIFF
--- a/app/src/main/res/xml/instagram_service_config.xml
+++ b/app/src/main/res/xml/instagram_service_config.xml
@@ -1,5 +1,7 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeWindowContentChanged|typeWindowStateChanged"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:packageNames="com.instagram.android"
     android:accessibilityFeedbackType="feedbackGeneric"
+    android:notificationTimeout="100"
     android:canRetrieveWindowContent="true"
     android:description="@string/instagram_service_description"/>


### PR DESCRIPTION
## Summary
- scope the InstagramPostService to `com.instagram.android`
- use fast retries to wait for the caption field
- include API level fallback when inserting caption text

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737111a15483278ca54e31a305c026