### PR TITLE
Fix Instagram caption insertion check

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/service/InstagramPostService.kt
+++ b/app/src/main/java/com/cicero/repostapp/service/InstagramPostService.kt
@@ -127,10 +127,23 @@ class InstagramPostService : AccessibilityService() {
                         editNode.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
                     }
                     editNode.performAction(AccessibilityNodeInfo.ACTION_PASTE)
-                    captionInserted = true
+
+                    // verify the caption text was actually inserted
+                    val confirmed = !editNode.text.isNullOrBlank()
+                    captionInserted = confirmed
                     handler.postDelayed(clickRunnable, stepDelayMs)
                     return
                 }
+            }
+        }
+
+        if (captionInserted) {
+            val editNode = waitForCaptionEditText()
+            if (editNode == null || editNode.text.isNullOrBlank()) {
+                // caption was not inserted successfully, retry instead of sharing
+                captionInserted = false
+                handler.postDelayed(clickRunnable, stepDelayMs)
+                return
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure caption text is inserted before tapping *Bagikan*
- re-check the caption field and retry on failure

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873876072a88327ae8c2a20f32999ad