### PR TITLE
Fix cleanup logic in InstagramPostService

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/service/InstagramPostService.kt
+++ b/app/src/main/java/com/cicero/repostapp/service/InstagramPostService.kt
@@ -326,8 +326,14 @@ class InstagramPostService : AccessibilityService() {
         waitingUpload = false
         sendBroadcast(Intent(ACTION_UPLOAD_FINISHED))
         performGlobalAction(GLOBAL_ACTION_HOME)
-        stopSelf()
+        disableSelf()
     }
 
     override fun onInterrupt() {}
+
+    override fun onDestroy() {
+        handler.removeCallbacks(clickRunnable)
+        handler.removeCallbacks(finishRunnable)
+        super.onDestroy()
+    }
 }


### PR DESCRIPTION
## Summary
- stop the service with `disableSelf()` instead of `stopSelf`
- remove pending callbacks when the service is destroyed

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68739676be68832783a81594bd13565f