### PR TITLE
Fix caption input for Instagram share

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -220,6 +220,9 @@ class AutopostFragment : Fragment(R.layout.fragment_autopost) {
             intent.putExtra(Intent.EXTRA_STREAM, uri)
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
+        if (!post.caption.isNullOrBlank()) {
+            intent.putExtra(Intent.EXTRA_TEXT, post.caption)
+        }
         intent.setPackage("com.instagram.android")
         intent.setClassName(
             "com.instagram.android",

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -355,6 +355,9 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
             val url = if (post.isVideo) post.videoUrl else post.imageUrl ?: post.sourceUrl
             if (!url.isNullOrBlank()) intent.putExtra(Intent.EXTRA_TEXT, url)
         }
+        if (!post.caption.isNullOrBlank()) {
+            intent.putExtra(Intent.EXTRA_TEXT, post.caption)
+        }
         val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         clipboard.setPrimaryClip(ClipData.newPlainText("caption", post.caption ?: ""))
         startActivity(Intent.createChooser(intent, "Share via"))


### PR DESCRIPTION
## Summary
- always pass caption text via EXTRA_TEXT on share intents

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68739ff7aa7c8327934668fa441fbd34