### PR TITLE
Fix build error by adding Error Prone annotation dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("com.google.code.gson:gson:2.10.1")
+    compileOnly("com.google.errorprone:error_prone_annotations:2.25.0")
     
 
 }


### PR DESCRIPTION
## Summary
- include `error_prone_annotations` as `compileOnly` in `app` module to resolve missing `CanIgnoreReturnValue`

## Testing
- `./gradlew help`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c58a7dbc8327a4071995db6edc57