### PR TITLE
Fix ErrorProne dependency conflict

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,9 @@ dependencies {
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("com.google.code.gson:gson:2.10.1")
-    compileOnly("com.google.errorprone:error_prone_annotations:2.25.0")
+    // Align with the version pulled in by the Android Gradle plugin to avoid
+    // dependency resolution conflicts during the build.
+    compileOnly("com.google.errorprone:error_prone_annotations:2.15.0")
     
 
 }


### PR DESCRIPTION
## Summary
- resolve dependency resolution issue by syncing with AGP's error-prone version

## Testing
- `./gradlew assembleRelease --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68744ac060b483278587fef93298705b