### PR TITLE
Redesign autopost page with 2FA support

### DIFF
--- a/public/autopost.html
+++ b/public/autopost.html
@@ -2,80 +2,186 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>AutoPost Login</title>
+    <title>AutoPost</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
-            text-align: center;
-            background: #f7f7f7;
-            padding: 40px;
+            margin: 0;
+            font-family: monospace;
+            background: #1f1f1f;
+            color: #33ff33;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
         }
-        form {
-            background: #fff;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,.1);
-            display: inline-block;
-        }
-        input {
-            margin: 8px 0;
-            padding: 8px;
-            width: 200px;
-        }
-        button {
-            padding: 8px 16px;
-            border: none;
-            border-radius: 4px;
-            background: #4CAF50;
-            color: #fff;
-            cursor: pointer;
-        }
-        #profile {
-            margin-top: 20px;
-        }
-        #profile img {
+        #instaIcon {
             width: 120px;
             height: 120px;
             border-radius: 50%;
             object-fit: cover;
+            cursor: pointer;
+            border: 2px solid #fff;
+        }
+        #startBtn {
+            margin-top: auto;
+            margin-bottom: 20px;
+            padding: 10px 20px;
+            background: #33ff33;
+            color: #1f1f1f;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.7);
+            display: none;
+            justify-content: center;
+            align-items: center;
+        }
+        .modal-content {
+            background: #000;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+        }
+        .modal-content input {
+            width: 200px;
+            margin: 6px 0;
+            padding: 6px;
+        }
+        .modal-content button {
+            padding: 6px 12px;
+        }
+        #checkMark {
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            width: 24px;
+            height: 24px;
+            border-radius: 50%;
+            background: #33ff33;
+            color: #000;
+            display: none;
+            justify-content: center;
+            align-items: center;
+            font-size: 16px;
+        }
+        #iconWrapper {
+            position: relative;
         }
     </style>
 </head>
 <body>
-    <h1>AutoPost Login</h1>
-    <form id="loginForm">
-        <input type="text" id="username" placeholder="Username" required><br>
-        <input type="password" id="password" placeholder="Password" required><br>
-        <button type="submit">Login</button>
-    </form>
-    <div id="profile" style="display:none;">
-        <img id="pPic" src="" alt="Profile Picture"><br>
-        <h2 id="pUser"></h2>
-        <p id="pName"></p>
-        <p>Followers: <span id="pFollowers"></span></p>
+    <div id="iconWrapper">
+        <img id="instaIcon" src="https://i.imgur.com/OK5yKjB.png" alt="Instagram">
+        <div id="checkMark">&#10004;</div>
     </div>
+    <button id="startBtn">Start</button>
+
+    <div id="loginModal" class="modal">
+        <div class="modal-content">
+            <input type="text" id="username" placeholder="Username"><br>
+            <input type="password" id="password" placeholder="Password"><br>
+            <button id="loginBtn">Login</button>
+        </div>
+    </div>
+
+    <div id="twofaModal" class="modal">
+        <div class="modal-content">
+            <p>Masukkan kode 2FA:</p>
+            <input type="text" id="twofaCode" placeholder="123456"><br>
+            <button id="twofaBtn">Verify</button>
+        </div>
+    </div>
+
+    <div id="checkpointModal" class="modal">
+        <div class="modal-content">
+            <p>Masukkan kode checkpoint:</p>
+            <input type="text" id="checkpointCode" placeholder="Code"><br>
+            <button id="checkpointBtn">Submit</button>
+        </div>
+    </div>
+
     <script>
-    document.getElementById('loginForm').addEventListener('submit', async function(e) {
-        e.preventDefault();
-        const username = document.getElementById('username').value;
-        const password = document.getElementById('password').value;
-        const resp = await fetch('/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, password })
+        const icon = document.getElementById('instaIcon');
+        const loginModal = document.getElementById('loginModal');
+        const twofaModal = document.getElementById('twofaModal');
+        const checkpointModal = document.getElementById('checkpointModal');
+        const checkMark = document.getElementById('checkMark');
+
+        icon.addEventListener('click', () => {
+            loginModal.style.display = 'flex';
         });
-        const data = await resp.json();
-        if (resp.ok) {
-            document.getElementById('loginForm').style.display = 'none';
-            document.getElementById('pPic').src = data.user.profilePic;
-            document.getElementById('pUser').textContent = data.user.username;
-            document.getElementById('pName').textContent = data.user.fullName;
-            document.getElementById('pFollowers').textContent = data.user.followerCount;
-            document.getElementById('profile').style.display = 'block';
-        } else {
-            alert(data.error || 'Login gagal');
-        }
-    });
+
+        document.getElementById('loginBtn').addEventListener('click', async () => {
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            const resp = await fetch('/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+            const data = await resp.json();
+            if (resp.ok) {
+                loginModal.style.display = 'none';
+                icon.src = data.user.profilePic;
+                checkMark.style.display = 'flex';
+            } else if (data.twoFactorRequired) {
+                loginModal.style.display = 'none';
+                twofaModal.dataset.username = username;
+                twofaModal.dataset.identifier = data.twoFactorIdentifier;
+                twofaModal.style.display = 'flex';
+            } else if (data.checkpoint) {
+                loginModal.style.display = 'none';
+                checkpointModal.dataset.username = username;
+                checkpointModal.style.display = 'flex';
+            } else {
+                alert(data.error || 'Login gagal');
+            }
+        });
+
+        document.getElementById('twofaBtn').addEventListener('click', async () => {
+            const username = twofaModal.dataset.username;
+            const identifier = twofaModal.dataset.identifier;
+            const code = document.getElementById('twofaCode').value;
+            const resp = await fetch('/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, twoFactorIdentifier: identifier, twoFactorCode: code })
+            });
+            const data = await resp.json();
+            if (resp.ok) {
+                twofaModal.style.display = 'none';
+                icon.src = data.user.profilePic;
+                checkMark.style.display = 'flex';
+            } else {
+                alert(data.error || 'Verifikasi gagal');
+            }
+        });
+
+        document.getElementById('checkpointBtn').addEventListener('click', async () => {
+            const username = checkpointModal.dataset.username;
+            const code = document.getElementById('checkpointCode').value;
+            const resp = await fetch('/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, checkpointCode: code })
+            });
+            const data = await resp.json();
+            if (resp.ok) {
+                checkpointModal.style.display = 'none';
+                icon.src = data.user.profilePic;
+                checkMark.style.display = 'flex';
+            } else {
+                alert(data.error || 'Checkpoint gagal');
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- revamp `autopost.html` with a minimal terminal-style layout
- show Instagram icon that triggers a login dialog
- add client-side handling for 2FA and checkpoint codes
- store temporary IG sessions and implement 2FA/checkpoint flow in `server.js`

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(starts server)*

------
https://chatgpt.com/codex/tasks/task_e_687471ad14948327a68ef261a3b976fb