### PR TITLE
Add instagram4j login with 2FA support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
     implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.github.instagram4j:instagram4j:2.0.7")
     // Align with the version pulled in by the Android Gradle plugin to avoid
     // dependency resolution conflicts during the build.
     compileOnly("com.google.errorprone:error_prone_annotations:2.15.0")


### PR DESCRIPTION
## Summary
- switch autopost login to use instagram4j library
- handle two factor authentication and checkpoint challenges
- add instagram4j dependency

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68747d4c8de08327be3858071466bbaf