### PR TITLE
Fix TextView parse error in autopost layout

### DIFF
--- a/app/src/main/res/layout/fragment_autopost.xml
+++ b/app/src/main/res/layout/fragment_autopost.xml
@@ -14,7 +14,7 @@
         android:padding="16dp"
         android:textColor="#00FF00"
         android:typeface="monospace"
-        android:text="> user@android:~$\n> echo \"Hello World\"\nHello World" />
+        android:text="@string/console_header_text" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,4 +38,5 @@
     <string name="whatsapp_message_registration">userrequest</string>
     <string name="accessibility_settings">Accessibility Service</string>
     <string name="enable_accessibility_service">Please enable accessibility service for auto posting</string>
+    <string name="console_header_text">&gt; user@android:~$&#10;&gt; echo &quot;Hello World&quot;&#10;Hello World</string>
 </resources>


### PR DESCRIPTION
## Summary
- fix parse error in `fragment_autopost.xml` by referencing a string resource
- add `console_header_text` string resource with escaped characters

## Testing
- `npm install`
- `npm start` *(terminated manually)*

------
https://chatgpt.com/codex/tasks/task_e_687481e165e88327b9cc139ffda17999