### PR TITLE
Improve autopost profile icon

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -111,7 +111,10 @@ class AutopostFragment : Fragment() {
                 saveSession(client)
                 val pic = client.selfProfile.profile_pic_url
                 withContext(Dispatchers.Main) {
-                    Glide.with(this@AutopostFragment).load(pic).into(icon)
+                    Glide.with(this@AutopostFragment)
+                        .load(pic)
+                        .circleCrop()
+                        .into(icon)
                     check.visibility = View.VISIBLE
                 }
             } catch (e: IGLoginException) {
@@ -170,7 +173,10 @@ class AutopostFragment : Fragment() {
             igClient = client
             val pic = client.selfProfile.profile_pic_url
             withContext(Dispatchers.Main) {
-                Glide.with(this@AutopostFragment).load(pic).into(icon)
+                Glide.with(this@AutopostFragment)
+                    .load(pic)
+                    .circleCrop()
+                    .into(icon)
                 check.visibility = View.VISIBLE
             }
         } catch (_: Exception) {

--- a/app/src/main/res/layout/fragment_autopost.xml
+++ b/app/src/main/res/layout/fragment_autopost.xml
@@ -41,7 +41,8 @@
                 android:layout_height="match_parent"
                 android:src="@drawable/ic_instagram"
                 android:background="@drawable/icon_border"
-                android:scaleType="centerCrop" />
+                android:scaleType="centerCrop"
+                android:clipToOutline="true" />
 
             <ImageView
                 android:id="@+id/check_mark"


### PR DESCRIPTION
## Summary
- show autopost profile pictures as circular images
- clip autopost icon outline to match circular border

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68748f1e1ba48327bde3ae83c98eb3be