### PR TITLE
Add .env support for Twitter keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TWITTER_CONSUMER_KEY=your_consumer_key
+TWITTER_CONSUMER_SECRET=your_consumer_secret
+TWITTER_CALLBACK_URL=repostapp-twitter://callback

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+# Local configuration
 local.properties
 .env
 node_modules/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Without this file the Android plugin cannot generate sources such as
 `BuildConfig`, which leads to errors like `Unresolved reference: BuildConfig` at
 compile time.
 
+The Twitter API keys used for login are loaded from a `.env` file in the project
+root. Copy `.env.example` to `.env` and fill in your credentials:
+
+```bash
+cp .env.example .env
+# edit .env and set TWITTER_CONSUMER_KEY and TWITTER_CONSUMER_SECRET
+```
+
 ## Update from GitHub Releases
 
 `MainActivity` includes a **Perbarui Aplikasi** button that queries the latest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,17 @@ plugins {
     kotlin("android")
 }
 
+import java.util.Properties
+
+val envProps = Properties()
+val envFile = rootProject.file(".env")
+if (envFile.exists()) {
+    envFile.inputStream().use { envProps.load(it) }
+}
+
+fun env(name: String): String =
+    envProps.getProperty(name) ?: System.getenv(name) ?: ""
+
 
 android {
     namespace = "com.cicero.repostapp"
@@ -15,9 +26,10 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.5.2"
-        buildConfigField("String", "TWITTER_CONSUMER_KEY", "\"\"")
-        buildConfigField("String", "TWITTER_CONSUMER_SECRET", "\"\"")
-        buildConfigField("String", "TWITTER_CALLBACK_URL", "\"repostapp-twitter://callback\"")
+        buildConfigField("String", "TWITTER_CONSUMER_KEY", "\"${env("TWITTER_CONSUMER_KEY")}\"")
+        buildConfigField("String", "TWITTER_CONSUMER_SECRET", "\"${env("TWITTER_CONSUMER_SECRET")}\"")
+        val callback = env("TWITTER_CALLBACK_URL").ifEmpty { "repostapp-twitter://callback" }
+        buildConfigField("String", "TWITTER_CALLBACK_URL", "\"$callback\"")
     }
 
     buildFeatures {


### PR DESCRIPTION
## Summary
- ignore `.env` and provide `.env.example`
- document how to use `.env`
- load Twitter credentials from `.env` in Gradle build

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d36fd34c8327acc9aac80f8161b7