### PR TITLE
Implement Facebook login on autopost page

### DIFF
--- a/app/src/main/res/layout/fragment_autopost.xml
+++ b/app/src/main/res/layout/fragment_autopost.xml
@@ -58,14 +58,33 @@
 
         </FrameLayout>
 
-        <ImageView
-            android:id="@+id/facebook_icon"
+        <FrameLayout
+            android:id="@+id/facebook_wrapper"
             android:layout_width="36dp"
             android:layout_height="36dp"
-            android:layout_marginStart="12dp"
-            android:src="@drawable/ic_facebook"
-            android:background="@drawable/icon_border"
-            android:scaleType="centerCrop" />
+            android:layout_marginStart="12dp">
+
+            <ImageView
+                android:id="@+id/facebook_icon"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/ic_facebook"
+                android:background="@drawable/icon_border"
+                android:scaleType="centerCrop"
+                android:clipToOutline="true" />
+
+            <ImageView
+                android:id="@+id/facebook_check"
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:layout_gravity="bottom|end"
+                android:layout_margin="2dp"
+                android:background="@drawable/check_mark_background"
+                android:src="@drawable/ic_status_true"
+                android:tint="@android:color/black"
+                android:visibility="gone" />
+
+        </FrameLayout>
 
         <FrameLayout
             android:id="@+id/twitter_wrapper"


### PR DESCRIPTION
## Summary
- add new UI wrapper with check mark for Facebook icon
- load and save Facebook session info
- allow logging in to Facebook by posting credentials to mobile login page

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f5fb3eec8327b94cc45df183951f