### PR TITLE
Improve FB login error message

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -239,10 +239,12 @@ class AutopostFragment : Fragment() {
                         }
                     } else {
                         val location = resp.header("Location") ?: ""
+                        val bodyStr = resp.body?.string()
                         val msg = when {
                             location.contains("checkpoint") -> "Akun memerlukan verifikasi (checkpoint)"
                             resp.code in 400..499 -> "Email atau password salah"
-                            else -> "Tidak dapat login ke Facebook"
+                            !bodyStr.isNullOrBlank() -> bodyStr
+                            else -> resp.message
                         }
                         withContext(Dispatchers.Main) { showErrorDialog(msg) }
                     }


### PR DESCRIPTION
## Summary
- show server response if Facebook login fails

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687505aa59748327aeb5611a953ad57d