### PR TITLE
Use WebView for Facebook login

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
         <activity android:name=".LoginActivity" />
         <activity android:name=".TwitterLoginActivity"
             android:exported="false" />
+        <activity android:name=".FacebookLoginActivity"
+            android:exported="false" />
         <activity android:name=".PremiumRegistrationActivity" />
         <activity android:name=".SubscriptionConfirmActivity" />
         <activity

--- a/app/src/main/java/com/cicero/repostapp/FacebookLoginActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/FacebookLoginActivity.kt
@@ -1,0 +1,45 @@
+package com.cicero.repostapp
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+
+class FacebookLoginActivity : AppCompatActivity() {
+    private lateinit var webView: WebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_facebook_login)
+        webView = findViewById(R.id.webview)
+
+        val ua = "Mozilla/5.0 (Linux; Android 13; SM-G990B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Mobile Safari/537.36"
+        val cookieManager = CookieManager.getInstance()
+        cookieManager.setAcceptCookie(true)
+        cookieManager.setAcceptThirdPartyCookies(webView, true)
+
+        webView.settings.javaScriptEnabled = true
+        webView.settings.userAgentString = ua
+        webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                val cookie = cookieManager.getCookie("https://m.facebook.com") ?: return
+                val userId = cookie.split(';').firstOrNull { it.trim().startsWith("c_user=") }
+                    ?.substringAfter('=')
+                if (userId != null) {
+                    val intent = Intent().apply {
+                        putExtra("userId", userId)
+                        putExtra("cookie", cookie)
+                    }
+                    setResult(Activity.RESULT_OK, intent)
+                    cookieManager.flush()
+                    finish()
+                }
+            }
+        }
+
+        webView.loadUrl("https://m.facebook.com/login.php")
+    }
+}

--- a/app/src/main/res/layout/activity_facebook_login.xml
+++ b/app/src/main/res/layout/activity_facebook_login.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WebView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/webview"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## Summary
- add a dedicated `FacebookLoginActivity` using a mobile user agent
- handle Facebook login via WebView instead of a dialog

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875deeef29c8327afb8fbc04ea8015e