### PR TITLE
Fix gradle version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The project uses Gradle Kotlin DSL. To build the project you would typically run
 ./gradlew assembleDebug
 ```
 
+The wrapper downloads **Gradle 8.7** the first time it runs. If you see an error
+such as `Minimum supported Gradle version is 8.4` make sure you are invoking the
+provided `./gradlew` script or update `gradle/wrapper/gradle-wrapper.properties`
+to use a Gradle distribution newer than 8.4.
+
 Before running the build you must point Gradle to a valid Android SDK
 installation.  Create a file named `local.properties` in the project root with
 the following content (adjust the path to match your environment):


### PR DESCRIPTION
## Summary
- clarify that the repo uses Gradle wrapper 8.7
- mention how to update the wrapper when the build fails with a lower version

## Testing
- `./gradlew --version | head -n 3`

------
https://chatgpt.com/codex/tasks/task_e_6875ef3224088327a5a6a8f90b50cb24