### PR TITLE
Fix repeated Twitter consumer key setup

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -318,7 +318,7 @@ class AutopostFragment : Fragment() {
     private suspend fun loadTwitterSession(icon: ImageView, check: ImageView) {
         val (token, profile, ok) = loadTwitterToken()
         if (!ok || token == null) return
-        val twitter = TwitterFactory.getSingleton().apply {
+        val twitter = TwitterFactory().instance.apply {
             setOAuthConsumer(BuildConfig.TWITTER_CONSUMER_KEY, BuildConfig.TWITTER_CONSUMER_SECRET)
             oAuthAccessToken = token
         }

--- a/app/src/main/java/com/cicero/repostapp/TwitterLoginActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterLoginActivity.kt
@@ -28,7 +28,7 @@ class TwitterLoginActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             withContext(Dispatchers.IO) {
-                twitter = TwitterFactory.getSingleton().apply {
+                twitter = TwitterFactory().instance.apply {
                     setOAuthConsumer(BuildConfig.TWITTER_CONSUMER_KEY, BuildConfig.TWITTER_CONSUMER_SECRET)
                 }
                 requestToken = twitter.getOAuthRequestToken(BuildConfig.TWITTER_CALLBACK_URL)


### PR DESCRIPTION
## Summary
- avoid reuse of Twitter4J singleton to prevent `IllegalStateException`

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687751c20f648327a48dcd70dcc14fa0