### PR TITLE
Support image carousel share

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
+++ b/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
@@ -16,8 +16,16 @@ data class InstaPost(
     val isVideo: Boolean = false,
     val videoUrl: String? = null,
     val sourceUrl: String? = null,
+    /**
+     * Additional image URLs when the post is a carousel.
+     */
+    val carouselImages: List<String> = emptyList(),
     var downloaded: Boolean = false,
     var localPath: String? = null,
+    /**
+     * Paths for downloaded carousel images.
+     */
+    var localCarouselPaths: MutableList<String> = mutableListOf(),
     var reported: Boolean = false
 )
 
@@ -54,7 +62,7 @@ class PostAdapter(
 
         fun bind(post: InstaPost) {
             captionText.text = post.caption ?: ""
-            val url = post.imageUrl
+            val url = post.imageUrl ?: post.carouselImages.firstOrNull()
             if (url != null && url.isNotBlank()) {
                 Glide.with(itemView).load(url).into(imageView)
             } else {


### PR DESCRIPTION
## Summary
- handle carousel post metadata in Dashboard page
- store additional image URLs and local paths
- download multiple images when necessary
- allow sharing multiple downloaded images at once

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_6877ac926cf88327a1f6db4ac921f91e