### PR TITLE
Fix unresolved url reference

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -340,7 +340,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
             } catch (e: Exception) {
                 Log.e(
                     "DashboardFragment",
-                    "Failed to download $url to $fileName: ${e.message}",
+                    "Failed to download $fileName: ${e.message}",
                     e
                 )
                 withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
- fix `DashboardFragment` download error message referring to nonexistent `url` variable

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b19421d88327b9d351b620c7282e