### PR TITLE
Implement premium check on autopost screen

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
@@ -58,8 +58,7 @@ class PremiumRegistrationActivity : AppCompatActivity() {
         button.setOnClickListener {
             val prefs = getSharedPreferences("auth", MODE_PRIVATE)
             val token = prefs.getString("token", "") ?: ""
-            val userId = prefs.getString("userId", "") ?: ""
-            if (token.isBlank() || userId.isBlank()) {
+            if (token.isBlank()) {
                 Toast.makeText(this, "Anda belum login", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,5 @@
     <string name="accessibility_settings">Accessibility Service</string>
     <string name="enable_accessibility_service">Please enable accessibility service for auto posting</string>
     <string name="console_header_text">&gt; user@android:~$&#10;&gt; echo &quot;Hello World&quot;&#10;Hello World</string>
+    <string name="premium_required">Fitur autopost hanya untuk pengguna premium</string>
 </resources>


### PR DESCRIPTION
## Summary
- add helpers for storing instagram username
- validate premium status using instagram username
- store the username whenever IG session is loaded
- clean up registration activity login check

## Testing
- `npm ls --depth=0`
- `npm install`
- `./gradlew tasks --all | head`


------
https://chatgpt.com/codex/tasks/task_e_6877c4d66e008327bf5dfc50dcb8bd8e