### PR TITLE
Add password toggle to login field

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -67,7 +67,8 @@
                         android:layout_height="wrap_content"
                         android:hint="@string/password"
                         android:layout_marginTop="16dp"
-                        app:startIconDrawable="@android:drawable/ic_lock_lock">
+                        app:startIconDrawable="@android:drawable/ic_lock_lock"
+                        app:endIconMode="password_toggle">
 
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/input_password"


### PR DESCRIPTION
## Summary
- add `password_toggle` end icon to password field

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877dc0fa93c8327b5b5057f701bed1a