### PR TITLE
Refactor API base URL into env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ TWITTER_CALLBACK_URL=repostapp-twitter://callback
 YOUTUBE_CLIENT_ID=your_youtube_client_id
 YOUTUBE_REDIRECT_URI=repostapp-youtube://oauth
 YOUTUBE_API_KEY=your_youtube_api_key
+API_BASE_URL=https://papiqo.com

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ root. Copy `.env.example` to `.env` and fill in your credentials:
 
 ```bash
 cp .env.example .env
-# edit .env and set TWITTER_CONSUMER_KEY and TWITTER_CONSUMER_SECRET
+# edit .env and set TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET
+# and API_BASE_URL if you need a different backend
 ```
 
 ## Update from GitHub Releases

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,8 @@ android {
         val ytRedirect = env("YOUTUBE_REDIRECT_URI").ifEmpty { "repostapp-youtube://oauth" }
         buildConfigField("String", "YOUTUBE_REDIRECT_URI", "\"$ytRedirect\"")
         buildConfigField("String", "YOUTUBE_API_KEY", "\"${env("YOUTUBE_API_KEY")}\"")
+        val apiBase = env("API_BASE_URL").ifEmpty { "https://papiqo.com" }
+        buildConfigField("String", "API_BASE_URL", "\"$apiBase\"")
     }
 
     buildFeatures {

--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -482,7 +482,7 @@ class AutopostFragment : Fragment() {
     private suspend fun hasActiveSubscription(token: String, userId: String): Boolean {
         val client = okhttp3.OkHttpClient()
         val req = okhttp3.Request.Builder()
-            .url("https://papiqo.com/api/premium-subscriptions/user/$userId/active")
+            .url("${BuildConfig.API_BASE_URL}/api/premium-subscriptions/user/$userId/active")
             .header("Authorization", "Bearer $token")
             .build()
         return try {
@@ -517,7 +517,7 @@ class AutopostFragment : Fragment() {
         suspend fun fetchClientId(): String? {
             val client = okhttp3.OkHttpClient()
             val req = okhttp3.Request.Builder()
-                .url("https://papiqo.com/api/users/$userId")
+                .url("${BuildConfig.API_BASE_URL}/api/users/$userId")
                 .header("Authorization", "Bearer $token")
                 .build()
             return try {
@@ -534,7 +534,7 @@ class AutopostFragment : Fragment() {
         suspend fun fetchPosts(clientId: String): List<InstaPost> {
             val posts = mutableListOf<InstaPost>()
             val client = okhttp3.OkHttpClient()
-            val url = "https://papiqo.com/api/insta/posts?client_id=$clientId"
+            val url = "${BuildConfig.API_BASE_URL}/api/insta/posts?client_id=$clientId"
             val req = okhttp3.Request.Builder().url(url).header("Authorization", "Bearer $token").build()
             try {
                 client.newCall(req).execute().use { resp ->
@@ -588,7 +588,7 @@ class AutopostFragment : Fragment() {
             val set = mutableSetOf<String>()
             val client = okhttp3.OkHttpClient()
             val req = okhttp3.Request.Builder()
-                .url("https://papiqo.com/api/link-reports")
+                .url("${BuildConfig.API_BASE_URL}/api/link-reports")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {
@@ -751,7 +751,7 @@ class AutopostFragment : Fragment() {
             val body = json.toString().toRequestBody("application/json".toMediaType())
             val client = okhttp3.OkHttpClient()
             val req = okhttp3.Request.Builder()
-                .url("https://papiqo.com/api/link-reports")
+                .url("${BuildConfig.API_BASE_URL}/api/link-reports")
                 .header("Authorization", "Bearer $token")
                 .post(body)
                 .build()

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -82,7 +82,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
             val req = Request.Builder()
-                .url("https://papiqo.com/api/users/$userId")
+                .url("${BuildConfig.API_BASE_URL}/api/users/$userId")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {
@@ -116,7 +116,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
     private fun fetchPosts(token: String, clientId: String) {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
-            val url = "https://papiqo.com/api/insta/posts?client_id=$clientId"
+            val url = "${BuildConfig.API_BASE_URL}/api/insta/posts?client_id=$clientId"
             val req = Request.Builder()
                 .url(url)
                 .header("Authorization", "Bearer $token")
@@ -461,7 +461,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         if (token.isBlank()) return null
         val client = OkHttpClient()
         val req = Request.Builder()
-            .url("https://papiqo.com/api/link-reports")
+            .url("${BuildConfig.API_BASE_URL}/api/link-reports")
             .header("Authorization", "Bearer $token")
             .build()
         return try {
@@ -540,7 +540,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         if (token.isBlank() || userId.isBlank()) return emptySet()
         val client = OkHttpClient()
         val req = Request.Builder()
-            .url("https://papiqo.com/api/link-reports")
+            .url("${BuildConfig.API_BASE_URL}/api/link-reports")
             .header("Authorization", "Bearer $token")
             .build()
         return try {

--- a/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
@@ -85,7 +85,7 @@ class LoginActivity : AppCompatActivity() {
             }
             val body = json.toString().toRequestBody("application/json".toMediaType())
             val request = Request.Builder()
-                .url("https://papiqo.com/api/auth/user-login")
+                .url("${BuildConfig.API_BASE_URL}/api/auth/user-login")
                 .post(body)
                 .build()
 
@@ -157,7 +157,7 @@ class LoginActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
             val request = Request.Builder()
-                .url("https://papiqo.com/api/users/$userId")
+                .url("${BuildConfig.API_BASE_URL}/api/users/$userId")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {
@@ -186,7 +186,7 @@ class LoginActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
             val checkReq = Request.Builder()
-                .url("https://papiqo.com/api/premium-subscriptions/user/$userId/active")
+                .url("${BuildConfig.API_BASE_URL}/api/premium-subscriptions/user/$userId/active")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {
@@ -204,7 +204,7 @@ class LoginActivity : AppCompatActivity() {
                         }
                         val body = json.toString().toRequestBody("application/json".toMediaType())
                         val postReq = Request.Builder()
-                            .url("https://papiqo.com/api/premium-subscriptions")
+                            .url("${BuildConfig.API_BASE_URL}/api/premium-subscriptions")
                             .header("Authorization", "Bearer $token")
                             .post(body)
                             .build()

--- a/app/src/main/java/com/cicero/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/MainActivity.kt
@@ -48,7 +48,7 @@ class MainActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
             val request = Request.Builder()
-                .url("https://papiqo.com/api/users/$userId")
+                .url("${BuildConfig.API_BASE_URL}/api/users/$userId")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {

--- a/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
@@ -79,7 +79,7 @@ class PremiumRegistrationActivity : AppCompatActivity() {
                 }
                 val body = json.toString().toRequestBody("application/json".toMediaType())
                 val request = Request.Builder()
-                    .url("https://papiqo.com/api/subscription-registrations")
+                    .url("${BuildConfig.API_BASE_URL}/api/subscription-registrations")
                     .header("Authorization", "Bearer $token")
                     .post(body)
                     .build()
@@ -110,7 +110,7 @@ class PremiumRegistrationActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
             val req = Request.Builder()
-                .url("https://papiqo.com/api/premium-subscriptions/user/$username/active")
+                .url("${BuildConfig.API_BASE_URL}/api/premium-subscriptions/user/$username/active")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -187,7 +187,7 @@ class ReportActivity : AppCompatActivity() {
         if (token.isBlank()) return null
         val client = OkHttpClient()
         val req = Request.Builder()
-            .url("https://papiqo.com/api/link-reports")
+            .url("${BuildConfig.API_BASE_URL}/api/link-reports")
             .header("Authorization", "Bearer $token")
             .build()
         return try {
@@ -239,7 +239,7 @@ class ReportActivity : AppCompatActivity() {
         if (token.isBlank()) return false
         val client = OkHttpClient()
         val req = Request.Builder()
-            .url("https://papiqo.com/api/link-reports")
+            .url("${BuildConfig.API_BASE_URL}/api/link-reports")
             .header("Authorization", "Bearer $token")
             .build()
         return try {
@@ -320,7 +320,7 @@ class ReportActivity : AppCompatActivity() {
                 val body = json.toString().toRequestBody("application/json".toMediaType())
                 val client = OkHttpClient()
                 val req = Request.Builder()
-                    .url("https://papiqo.com/api/link-reports")
+                    .url("${BuildConfig.API_BASE_URL}/api/link-reports")
                     .header("Authorization", "Bearer $token")
                     .post(body)
                     .build()

--- a/app/src/main/java/com/cicero/repostapp/SplashActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/SplashActivity.kt
@@ -31,7 +31,7 @@ class SplashActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
             val request = Request.Builder()
-                .url("https://papiqo.com/api/users/$userId")
+                .url("${BuildConfig.API_BASE_URL}/api/users/$userId")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {

--- a/app/src/main/java/com/cicero/repostapp/SubscriptionConfirmActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/SubscriptionConfirmActivity.kt
@@ -37,7 +37,7 @@ class SubscriptionConfirmActivity : AppCompatActivity() {
                 val json = JSONObject().apply { put("username", username) }
                 val body = json.toString().toRequestBody("application/json".toMediaType())
                 val req = Request.Builder()
-                    .url("https://papiqo.com/api/subscription-confirmations")
+                    .url("${BuildConfig.API_BASE_URL}/api/subscription-confirmations")
                     .header("Authorization", "Bearer $token")
                     .post(body)
                     .build()

--- a/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
@@ -55,7 +55,7 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
         CoroutineScope(Dispatchers.IO).launch {
             val client = OkHttpClient()
             val request = Request.Builder()
-                .url("https://papiqo.com/api/users/$userId")
+                .url("${BuildConfig.API_BASE_URL}/api/users/$userId")
                 .header("Authorization", "Bearer $token")
                 .build()
             try {
@@ -137,7 +137,7 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
                     (stats?.optInt("following_count") ?: 0).toString()
                 val avatarUrl = stats?.optString("profile_pic_url") ?: ""
                 val fullAvatarUrl = if (avatarUrl.startsWith("http"))
-                    avatarUrl else "https://papiqo.com$avatarUrl"
+                    avatarUrl else "${BuildConfig.API_BASE_URL}$avatarUrl"
 
                 Glide.with(this@UserProfileFragment)
                     .load(fullAvatarUrl)
@@ -153,7 +153,7 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
     private fun getStatsFromDb(token: String, username: String): Pair<JSONObject?, String?> {
         val client = OkHttpClient()
         val req = Request.Builder()
-            .url("https://papiqo.com/api/insta/profile?username=$username")
+            .url("${BuildConfig.API_BASE_URL}/api/insta/profile?username=$username")
             .header("Authorization", "Bearer $token")
             .build()
         return try {
@@ -171,7 +171,7 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
     private fun fetchAndStoreStats(token: String, username: String) {
         val client = OkHttpClient()
         val req = Request.Builder()
-            .url("https://papiqo.com/api/insta/rapid-profile?username=$username")
+            .url("${BuildConfig.API_BASE_URL}/api/insta/rapid-profile?username=$username")
             .header("Authorization", "Bearer $token")
             .build()
         try {


### PR DESCRIPTION
## Summary
- move backend API base url to `.env`
- reference `BuildConfig.API_BASE_URL` in Kotlin code
- document new env variable in README

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e085fb488327b1ce8170ecf9ae80