### PR TITLE
Enable autopost start for premium subscribers

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -41,6 +41,7 @@ class AutopostFragment : Fragment() {
 
     private var igClient: IGClient? = null
     private var twitterToken: AccessToken? = null
+    private var premiumActive: Boolean = false
 
     private fun showErrorDialog(message: String) {
         AlertDialog.Builder(requireContext())
@@ -214,6 +215,14 @@ class AutopostFragment : Fragment() {
             loadTwitterSession(twitterIcon, twitterCheck)
             loadTikTokSession(tiktokIcon, tiktokCheck)
             loadYoutubeSession(youtubeIcon, youtubeCheck)
+            val prefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+            val token = prefs.getString("token", "") ?: ""
+            val userId = prefs.getString("userId", "") ?: ""
+            premiumActive = token.isNotBlank() && userId.isNotBlank() &&
+                hasActiveSubscription(token, userId)
+            withContext(Dispatchers.Main) {
+                start.isEnabled = premiumActive
+            }
         }
 
         icon.setOnClickListener { showLoginDialog(icon, check) }
@@ -223,15 +232,11 @@ class AutopostFragment : Fragment() {
         youtubeIcon.setOnClickListener { launchYoutubeLogin() }
         start.setOnClickListener {
             lifecycleScope.launch(Dispatchers.IO) {
-                val prefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
-                val token = prefs.getString("token", "") ?: ""
-                val userId = prefs.getString("userId", "") ?: ""
-                val premium = if (token.isNotBlank() && userId.isNotBlank()) {
-                    hasActiveSubscription(token, userId)
-                } else false
-                if (!premium) {
+                if (!premiumActive) {
                     withContext(Dispatchers.Main) {
                         Toast.makeText(requireContext(), getString(R.string.premium_required), Toast.LENGTH_SHORT).show()
+                        val prefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+                        val userId = prefs.getString("userId", "") ?: ""
                         val intent = Intent(requireContext(), PremiumRegistrationActivity::class.java)
                         intent.putExtra("userId", userId)
                         startActivity(intent)


### PR DESCRIPTION
## Summary
- enable autopost Start button only when user has an active premium subscription
- reuse stored check result when the Start button is pressed

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789f304cb88327b4e181d710e0b405