### PR TITLE
Remove logout button from profile page

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
@@ -5,8 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
-import android.widget.Button
-import android.content.Intent
 import android.content.Context
 import android.widget.ImageView
 import androidx.core.content.edit
@@ -38,13 +36,6 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
         super.onViewCreated(view, savedInstanceState)
         val userId = arguments?.getString(ARG_USER_ID) ?: ""
         val token = arguments?.getString(ARG_TOKEN) ?: ""
-        view.findViewById<Button>(R.id.button_logout).setOnClickListener {
-            val prefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
-            prefs.edit { clear() }
-            val intent = Intent(requireContext(), MainActivity::class.java)
-            startActivity(intent)
-            activity?.finish()
-        }
         if (userId.isNotBlank() && token.isNotBlank()) {
             fetchProfile(userId, token, view)
         }

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -270,14 +270,5 @@
 
         </LinearLayout>
 
-        <Button
-            android:id="@+id/button_logout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/logout"
-            android:layout_marginTop="24dp"
-            app:layout_constraintTop_toBottomOf="@id/info_container"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>


### PR DESCRIPTION
## Summary
- remove the logout button from the profile layout
- drop related listener and unused imports in `UserProfileFragment`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878aefa046883278aace38c96c5f497