### PR TITLE
Remove body-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "tiktok-login",
       "version": "1.0.0",
       "dependencies": {
-        "body-parser": "^1.20.2",
         "express": "^4.18.2",
         "instagram-private-api": "^1.46.1",
         "node-html-parser": "^7.0.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "body-parser": "^1.20.2",
     "express": "^4.18.2",
     "instagram-private-api": "^1.46.1",
     "node-html-parser": "^7.0.1"

--- a/server.js
+++ b/server.js
@@ -1,10 +1,9 @@
 import express from 'express';
-import bodyParser from 'body-parser';
 import { IgApiClient, IgLoginTwoFactorRequiredError, IgCheckpointError } from 'instagram-private-api';
 
 const app = express();
 app.use(express.static('public'));
-app.use(bodyParser.json());
+app.use(express.json());
 
 // store temporary IgApiClient sessions for 2FA/checkpoint handling
 // each entry holds an object { client: IgApiClient, timestamp: number }


### PR DESCRIPTION
## Summary
- drop unused body-parser import
- configure Express to use its built-in JSON parser
- remove body-parser dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878fda2a5c8832781db4a79439d2483