### PR TITLE
Replace placeholder image descriptions

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -22,7 +22,7 @@
                 android:id="@+id/logo"
                 android:layout_width="240dp"
                 android:layout_height="240dp"
-                android:contentDescription="@string/todo"
+                android:contentDescription="@string/login_logo"
                 android:src="@mipmap/ic_launcher_foreground"
                 tools:ignore="ImageContrastCheck" />
 

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -18,7 +18,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:contentDescription="@string/todo" />
+            android:contentDescription="@string/profile_cover" />
 
         <ImageView
             android:id="@+id/image_avatar"
@@ -26,7 +26,7 @@
             android:layout_height="110dp"
             android:layout_marginTop="-55dp"
             android:background="@drawable/avatar_background"
-            android:contentDescription="@string/todo"
+            android:contentDescription="@string/profile_avatar"
             android:scaleType="centerCrop"
             android:src="@drawable/profile_avatar_placeholder"
             app:layout_constraintEnd_toEndOf="parent"
@@ -39,7 +39,7 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_margin="4dp"
-            android:contentDescription="TODO"
+            android:contentDescription="@string/profile_status"
             android:src="@drawable/ic_status_true"
             app:layout_constraintBottom_toBottomOf="@id/image_avatar"
             app:layout_constraintEnd_toEndOf="@id/image_avatar"
@@ -51,7 +51,7 @@
             android:layout_height="24dp"
             android:layout_margin="4dp"
             android:src="@drawable/ic_badge_basic"
-            android:contentDescription="@string/todo"
+            android:contentDescription="@string/profile_badge"
             app:layout_constraintBottom_toBottomOf="@id/image_avatar"
             app:layout_constraintEnd_toStartOf="@id/image_status" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,11 @@
     <string name="username_tiktok">Username TikTok</string>
     <string name="username_instagram">Username Instagram</string>
     <string name="logout">Logout</string>
-    <string name="todo">TODO</string>
+    <string name="profile_cover">Profile cover image</string>
+    <string name="profile_avatar">Profile avatar</string>
+    <string name="profile_status">Profile status indicator</string>
+    <string name="profile_badge">Profile badge</string>
+    <string name="login_logo">Application logo</string>
     <string name="_0">0</string>
     <string name="nama">Nama</string>
     <string name="nrp">NRP</string>


### PR DESCRIPTION
## Summary
- stop using `@string/todo` placeholders in layouts
- add descriptive content descriptions
- declare new string resources for profile and login images

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879003fbd9c8327b15ed5c8274acfa3