### PR TITLE
Fix multi-image download handling

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
+++ b/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
@@ -26,6 +26,10 @@ data class InstaPost(
      * Paths for downloaded carousel images.
      */
     var localCarouselPaths: MutableList<String> = mutableListOf(),
+    /**
+     * Directory containing downloaded carousel images.
+     */
+    var localCarouselDir: String? = null,
     var reported: Boolean = false
 )
 


### PR DESCRIPTION
## Summary
- add field to keep carousel folder path
- adjust file existence check and download logic to use shortcode folders
- update sharing logic to gather images from shortcode folders
- update autopost to store multi-image downloads in folders

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc981e10c8327b28bba2fc2f39389