### PR TITLE
Fix carousel parsing for images_url

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -555,7 +555,8 @@ class AutopostFragment : Fragment() {
                         } catch (_: Exception) { null }
                         if (createdDate == today) {
                             val id = obj.optString("shortcode")
-                            val carouselArr = obj.optJSONArray("image_urls")
+                            val carouselArr = obj.optJSONArray("images_url")
+                                ?: obj.optJSONArray("image_urls")
                                 ?: obj.optJSONArray("carousel")
                                 ?: obj.optJSONArray("carousel_images")
                             val carousel = mutableListOf<String>()

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -148,7 +148,8 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                                 } catch (_: Exception) { null }
                                 if (createdDate == today) {
                                     val id = obj.optString("shortcode")
-                                    val carouselArr = obj.optJSONArray("image_urls")
+                                    val carouselArr = obj.optJSONArray("images_url")
+                                        ?: obj.optJSONArray("image_urls")
                                         ?: obj.optJSONArray("carousel")
                                         ?: obj.optJSONArray("carousel_images")
                                     val carousel = mutableListOf<String>()


### PR DESCRIPTION
## Summary
- parse `images_url` when building post carousel list in dashboard and autopost

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687de86ac0a483278b723d10901e2615