### PR TITLE
Add numbering for post reports

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -573,6 +573,7 @@ class AutopostFragment : Fragment() {
                                     caption = obj.optString("caption"),
                                     imageUrl = obj.optString("image_url").ifBlank { obj.optString("thumbnail_url") }.ifBlank { carousel.firstOrNull() },
                                     createdAt = created,
+                                    taskNumber = posts.size + 1,
                                     isVideo = obj.optBoolean("is_video"),
                                     videoUrl = obj.optString("video_url"),
                                     sourceUrl = obj.optString("source_url"),

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -168,6 +168,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                                                 .ifBlank { obj.optString("thumbnail_url") }
                                                 .ifBlank { carousel.firstOrNull() },
                                             createdAt = created,
+                                            taskNumber = posts.size + 1,
                                             isVideo = obj.optBoolean("is_video"),
                                             videoUrl = obj.optString("video_url"),
                                             sourceUrl = obj.optString("source_url"),
@@ -442,11 +443,12 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                             putExtra(ReportActivity.EXTRA_IMAGE_URL, post.imageUrl)
                             putExtra(ReportActivity.EXTRA_CAPTION, post.caption)
                             putExtra(ReportActivity.EXTRA_SHORTCODE, post.id)
+                            putExtra(ReportActivity.EXTRA_TASK_NUMBER, post.taskNumber)
                         }
                         startActivity(intent)
                     }
                     2 -> if (post.reported) {
-                        shareReportViaWhatsApp(post.id)
+                        shareReportViaWhatsApp(post.id, post.taskNumber)
                     }
                 }
             }
@@ -466,12 +468,12 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         }
     }
 
-    private fun shareReportViaWhatsApp(shortcode: String) {
+    private fun shareReportViaWhatsApp(shortcode: String, taskNumber: Int) {
         CoroutineScope(Dispatchers.IO).launch {
             val links = getExistingReport(shortcode)
             if (links != null) {
                 withContext(Dispatchers.Main) {
-                    shareViaWhatsApp(shortcode, links)
+                    shareViaWhatsApp(shortcode, taskNumber, links)
                 }
             } else {
                 withContext(Dispatchers.Main) {
@@ -542,7 +544,7 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         }
     }
 
-    private fun shareViaWhatsApp(shortcode: String, links: Map<String, String?>) {
+    private fun shareViaWhatsApp(shortcode: String, taskNumber: Int, links: Map<String, String?>) {
         val locale = java.util.Locale("id", "ID")
         val today = java.time.LocalDate.now()
         val day = today.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale))
@@ -559,6 +561,8 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         """.trimIndent()
 
         val message = """
+            Laporan Tugas $taskNumber
+
             Mohon ijin, Mengirimkan Laporan repost konten,
 
             Hari : $day,

--- a/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
+++ b/app/src/main/java/com/cicero/repostapp/PostAdapter.kt
@@ -13,6 +13,10 @@ data class InstaPost(
     val caption: String?,
     val imageUrl: String?,
     val createdAt: String,
+    /**
+     * Sequential task number as fetched from the API queue.
+     */
+    val taskNumber: Int = 0,
     val isVideo: Boolean = false,
     val videoUrl: String? = null,
     val sourceUrl: String? = null,
@@ -69,7 +73,8 @@ class PostAdapter(
         private val reportedIcon: ImageView = itemView.findViewById(R.id.icon_reported)
 
         fun bind(post: InstaPost) {
-            captionText.text = post.caption ?: ""
+            val cap = post.caption ?: ""
+            captionText.text = "Laporan Tugas ${post.taskNumber}\n$cap"
             val url = post.imageUrl ?: post.carouselImages.firstOrNull()
             if (url != null && url.isNotBlank()) {
                 Glide.with(itemView).load(url).into(imageView)

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -28,6 +28,7 @@ class ReportActivity : AppCompatActivity() {
         const val EXTRA_IMAGE_URL = "image_url"
         const val EXTRA_CAPTION = "caption"
         const val EXTRA_SHORTCODE = "shortcode"
+        const val EXTRA_TASK_NUMBER = "task_number"
     }
 
     private data class Platform(
@@ -41,6 +42,7 @@ class ReportActivity : AppCompatActivity() {
     private lateinit var platforms: List<Platform>
     private lateinit var token: String
     private lateinit var userId: String
+    private var taskNumber: Int = 0
     private var shortcode: String? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,6 +65,8 @@ class ReportActivity : AppCompatActivity() {
             captionView.text = caption
         }
         shortcode = intent.getStringExtra(EXTRA_SHORTCODE)
+        taskNumber = intent.getIntExtra(EXTRA_TASK_NUMBER, 0)
+        findViewById<TextView>(R.id.task_number).text = "Laporan Tugas $taskNumber"
 
         platforms = listOf(
             Platform(
@@ -330,7 +334,7 @@ class ReportActivity : AppCompatActivity() {
                 withContext(Dispatchers.Main) {
                     if (success) {
                         Toast.makeText(this@ReportActivity, "Laporan terkirim", Toast.LENGTH_SHORT).show()
-                        shareViaWhatsApp(shortcodeVal ?: "", links)
+                        shareViaWhatsApp(shortcodeVal ?: "", taskNumber, links)
                         finish()
                     } else {
                         Toast.makeText(this@ReportActivity, "Gagal mengirim laporan", Toast.LENGTH_SHORT).show()
@@ -344,7 +348,7 @@ class ReportActivity : AppCompatActivity() {
         }
     }
 
-    private fun shareViaWhatsApp(shortcode: String, links: Map<String, String?>) {
+    private fun shareViaWhatsApp(shortcode: String, taskNumber: Int, links: Map<String, String?>) {
         val locale = java.util.Locale("id", "ID")
         val today = java.time.LocalDate.now()
         val day = today.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale))
@@ -361,6 +365,8 @@ class ReportActivity : AppCompatActivity() {
         """.trimIndent()
 
         val message = """
+            Laporan Tugas $taskNumber
+
             Mohon ijin, Mengirimkan Laporan repost konten,
 
             Hari : $day,

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -17,6 +17,13 @@
             android:src="@android:drawable/ic_menu_gallery" />
 
         <TextView
+            android:id="@+id/task_number"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:paddingTop="8dp" />
+
+        <TextView
             android:id="@+id/caption_preview"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- include a `taskNumber` field in `InstaPost`
- show the task number in post captions
- carry task number when launching `ReportActivity`
- display numbering in WhatsApp share messages
- show current task number in the report form

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e39f1e3f0832788d8647e48f13469