### PR TITLE
Sort fetched posts chronologically

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -180,6 +180,19 @@ class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
                                     )
                                 }
                             }
+                            val parseTs: (String) -> Long = { ts ->
+                                try {
+                                    if (ts.contains("T")) {
+                                        java.time.OffsetDateTime.parse(ts)
+                                            .toInstant().toEpochMilli()
+                                    } else {
+                                        java.time.LocalDateTime.parse(ts, formatter)
+                                            .atZone(java.time.ZoneId.systemDefault())
+                                            .toInstant().toEpochMilli()
+                                    }
+                                } catch (_: Exception) { 0L }
+                            }
+                            posts.sortBy { parseTs(it.createdAt) }
                             adapter.setData(posts)
                             emptyView.visibility = if (posts.isEmpty()) View.VISIBLE else View.GONE
                             progressBar.visibility = View.GONE


### PR DESCRIPTION
## Summary
- sort fetched Instagram posts by timestamp so older entries appear first

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3dc5ce7083278266e885a33aa64f