### PR TITLE
Add special tasks page

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
@@ -24,6 +24,7 @@ class DashboardActivity : AppCompatActivity() {
         val fragments = listOf(
             UserProfileFragment.newInstance(userId, token),
             DashboardFragment.newInstance(userId, token),
+            SpecialTaskFragment.newInstance(userId, token),
             AutopostFragment.newInstance()
         )
 
@@ -39,7 +40,8 @@ class DashboardActivity : AppCompatActivity() {
             when (item.itemId) {
                 R.id.nav_profile -> { viewPager.currentItem = 0; true }
                 R.id.nav_insta -> { viewPager.currentItem = 1; true }
-                R.id.nav_autopost -> { viewPager.currentItem = 2; true }
+                R.id.nav_special -> { viewPager.currentItem = 2; true }
+                R.id.nav_autopost -> { viewPager.currentItem = 3; true }
                 else -> false
             }
         }
@@ -49,7 +51,8 @@ class DashboardActivity : AppCompatActivity() {
                 when (position) {
                     0 -> bottomNav.selectedItemId = R.id.nav_profile
                     1 -> bottomNav.selectedItemId = R.id.nav_insta
-                    2 -> bottomNav.selectedItemId = R.id.nav_autopost
+                    2 -> bottomNav.selectedItemId = R.id.nav_special
+                    3 -> bottomNav.selectedItemId = R.id.nav_autopost
                 }
             }
         })

--- a/app/src/main/java/com/cicero/repostapp/SpecialTaskAdapter.kt
+++ b/app/src/main/java/com/cicero/repostapp/SpecialTaskAdapter.kt
@@ -1,0 +1,50 @@
+package com.cicero.repostapp
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * Simple adapter to show special task recap per user.
+ */
+class SpecialTaskAdapter(
+    private val items: MutableList<SpecialTask>
+) : RecyclerView.Adapter<SpecialTaskAdapter.TaskViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TaskViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_special_task, parent, false)
+        return TaskViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: TaskViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    fun setData(data: List<SpecialTask>) {
+        items.clear()
+        items.addAll(data)
+        notifyDataSetChanged()
+    }
+
+    class TaskViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val nameText: TextView = itemView.findViewById(R.id.text_name)
+        private val countText: TextView = itemView.findViewById(R.id.text_count)
+        fun bind(task: SpecialTask) {
+            nameText.text = task.displayName
+            countText.text = "${task.linkCount} link"
+        }
+    }
+}
+
+/**
+ * Data class representing special task recap for a user.
+ */
+data class SpecialTask(
+    val displayName: String,
+    val linkCount: Int
+)

--- a/app/src/main/java/com/cicero/repostapp/SpecialTaskFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/SpecialTaskFragment.kt
@@ -1,0 +1,135 @@
+package com.cicero.repostapp
+
+import android.os.Bundle
+import android.view.View
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Fragment to display recap of special tasks from backend.
+ */
+class SpecialTaskFragment : Fragment(R.layout.fragment_special_task) {
+
+    companion object {
+        private const val ARG_USER_ID = "userId"
+        private const val ARG_TOKEN = "token"
+
+        fun newInstance(userId: String?, token: String?): SpecialTaskFragment {
+            val f = SpecialTaskFragment()
+            f.arguments = bundleOf(ARG_USER_ID to userId, ARG_TOKEN to token)
+            return f
+        }
+    }
+
+    private lateinit var adapter: SpecialTaskAdapter
+    private lateinit var progress: ProgressBar
+    private lateinit var emptyView: TextView
+    private var token: String = ""
+    private var userId: String = ""
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        adapter = SpecialTaskAdapter(mutableListOf())
+        val recycler = view.findViewById<RecyclerView>(R.id.recycler_special)
+        recycler.layoutManager = LinearLayoutManager(requireContext())
+        recycler.adapter = adapter
+        progress = view.findViewById(R.id.progress_special)
+        emptyView = view.findViewById(R.id.text_empty_special)
+        token = arguments?.getString(ARG_TOKEN) ?: ""
+        userId = arguments?.getString(ARG_USER_ID) ?: ""
+        if (token.isNotBlank() && userId.isNotBlank()) {
+            progress.visibility = View.VISIBLE
+            CoroutineScope(Dispatchers.IO).launch {
+                fetchClientAndTasks()
+            }
+        }
+    }
+
+    private suspend fun fetchClientAndTasks() {
+        val client = OkHttpClient()
+        val req = Request.Builder()
+            .url("${BuildConfig.API_BASE_URL}/api/users/$userId")
+            .header("Authorization", "Bearer $token")
+            .build()
+        try {
+            client.newCall(req).execute().use { resp ->
+                val body = resp.body?.string()
+                val clientId = if (resp.isSuccessful) {
+                    try {
+                        JSONObject(body ?: "{}")
+                            .optJSONObject("data")
+                            ?.optString("client_id") ?: ""
+                    } catch (_: Exception) { "" }
+                } else ""
+                withContext(Dispatchers.Main) {
+                    if (clientId.isNotBlank()) {
+                        fetchTasks(clientId)
+                    } else {
+                        progress.visibility = View.GONE
+                        Toast.makeText(requireContext(), "Gagal memuat data", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            withContext(Dispatchers.Main) {
+                progress.visibility = View.GONE
+                Toast.makeText(requireContext(), "Gagal terhubung ke server", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun fetchTasks(clientId: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val client = OkHttpClient()
+            val url = "${BuildConfig.API_BASE_URL}/api/amplify-khusus/rekap?client_id=$clientId"
+            val req = Request.Builder()
+                .url(url)
+                .header("Authorization", "Bearer $token")
+                .build()
+            try {
+                client.newCall(req).execute().use { resp ->
+                    val body = resp.body?.string()
+                    withContext(Dispatchers.Main) {
+                        emptyView.visibility = View.GONE
+                        if (resp.isSuccessful) {
+                            val arr = try {
+                                JSONObject(body ?: "{}").optJSONArray("data") ?: JSONArray()
+                            } catch (_: Exception) { JSONArray() }
+                            val list = mutableListOf<SpecialTask>()
+                            for (i in 0 until arr.length()) {
+                                val obj = arr.optJSONObject(i) ?: continue
+                                val display = obj.optString("display_nama")
+                                val count = obj.optInt("jumlah_link")
+                                list.add(SpecialTask(display, count))
+                            }
+                            adapter.setData(list)
+                            emptyView.visibility = if (list.isEmpty()) View.VISIBLE else View.GONE
+                            progress.visibility = View.GONE
+                        } else {
+                            progress.visibility = View.GONE
+                            Toast.makeText(requireContext(), "Gagal mengambil data", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    progress.visibility = View.GONE
+                    Toast.makeText(requireContext(), "Gagal terhubung ke server", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_special_task.xml
+++ b/app/src/main/res/layout/fragment_special_task.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_special"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <TextView
+        android:id="@+id/text_empty_special"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Belum ada data"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+
+    <ProgressBar
+        android:id="@+id/progress_special"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+</FrameLayout>

--- a/app/src/main/res/layout/item_special_task.xml
+++ b/app/src/main/res/layout/item_special_task.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/text_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Nama" />
+
+    <TextView
+        android:id="@+id/text_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="0 link" />
+</LinearLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -9,6 +9,10 @@
         android:icon="@android:drawable/ic_menu_gallery"
         android:title="Konten" />
     <item
+        android:id="@+id/nav_special"
+        android:icon="@android:drawable/ic_menu_agenda"
+        android:title="Tugas Khusus" />
+    <item
         android:id="@+id/nav_autopost"
         android:icon="@android:drawable/ic_menu_upload"
         android:title="Autopost" />


### PR DESCRIPTION
## Summary
- add `SpecialTaskFragment` and adapter to show special task recap data
- extend `DashboardActivity` view pager with the new fragment
- update bottom navigation menu layout

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5b610e70832790b1d3606c39ac89