### PR TITLE
Remove premium check from autopost start

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -223,22 +223,7 @@ class AutopostFragment : Fragment() {
         youtubeIcon.setOnClickListener { launchYoutubeLogin() }
         start.setOnClickListener {
             lifecycleScope.launch(Dispatchers.IO) {
-                val prefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
-                val token = prefs.getString("token", "") ?: ""
-                val userId = prefs.getString("userId", "") ?: ""
-                val premium = if (token.isNotBlank() && userId.isNotBlank()) {
-                    hasActiveSubscription(token, userId)
-                } else false
-                if (!premium) {
-                    withContext(Dispatchers.Main) {
-                        Toast.makeText(requireContext(), getString(R.string.premium_required), Toast.LENGTH_SHORT).show()
-                        val intent = Intent(requireContext(), PremiumRegistrationActivity::class.java)
-                        intent.putExtra("userId", userId)
-                        startActivity(intent)
-                    }
-                } else {
-                    runAutopostWorkflow()
-                }
+                runAutopostWorkflow()
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow autopost workflow to start without verifying premium subscription

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5d5911b88327b0f10e779779fad5