### PR TITLE
Fix local function modifiers in AutopostFragment

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -888,7 +888,7 @@ class AutopostFragment : Fragment() {
             }
         }
 
-        private suspend fun postToTwitter(post: InstaPost, file: File): String? {
+        suspend fun postToTwitter(post: InstaPost, file: File): String? {
             appendLog("Posting ke Twitter…")
             // Placeholder implementation using accessibility service
             delay(2000)
@@ -898,7 +898,7 @@ class AutopostFragment : Fragment() {
             } catch (_: Exception) { null }
         }
 
-        private suspend fun postToTikTok(post: InstaPost, file: File): String? {
+        suspend fun postToTikTok(post: InstaPost, file: File): String? {
             appendLog("Posting ke TikTok…")
             delay(2000)
             return try {


### PR DESCRIPTION
## Summary
- fix Kotlin compiler errors by removing `private` from the nested `postToTwitter` and `postToTikTok` functions

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_688381edd1748327badf43663908e04a