### PR TITLE
Add Twitter autopost with accessibility service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,17 @@
         <activity
             android:name=".MainActivity"
             android:exported="true" />
+        <service
+            android:name=".TwitterAutoPostService"
+            android:exported="false"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
         <!-- Autopost functionality handled outside of accessibility services -->
     </application>
 </manifest>

--- a/app/src/main/java/com/cicero/repostapp/TwitterAutoPostService.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterAutoPostService.kt
@@ -1,0 +1,57 @@
+package com.cicero.repostapp
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.os.Bundle
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+
+/**
+ * AccessibilityService to automate composing tweet using stored text.
+ */
+class TwitterAutoPostService : AccessibilityService() {
+
+    override fun onServiceConnected() {
+        // Configure the service to listen to Twitter app only
+        serviceInfo = serviceInfo.apply {
+            eventTypes = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED or
+                    AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+            packageNames = arrayOf("com.twitter.android")
+            feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+        }
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        if (event?.packageName != "com.twitter.android") return
+        val root = rootInActiveWindow ?: return
+        val prefs = getSharedPreferences("twitter_post_prefs", MODE_PRIVATE)
+        val text = prefs.getString("twitter_post_text", null) ?: return
+
+        // 1. open compose tweet
+        val fab = root.findAccessibilityNodeInfosByViewId("com.twitter.android:id/fab").firstOrNull()
+        if (fab != null) {
+            fab.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+            return
+        }
+
+        // 2. fill tweet text
+        val tweetField = root.findAccessibilityNodeInfosByViewId("com.twitter.android:id/tweet_text").firstOrNull()
+        if (tweetField != null && tweetField.text.isNullOrEmpty()) {
+            val args = Bundle()
+            args.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
+            tweetField.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+            return
+        }
+
+        // 3. send tweet
+        val tweetButton = root.findAccessibilityNodeInfosByText("Tweet").firstOrNull()
+        if (tweetButton != null && tweetField != null && tweetField.text?.toString() == text) {
+            tweetButton.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+            // Clear stored text after posting
+            prefs.edit().clear().apply()
+            // TODO: capture tweet link and report to server
+        }
+    }
+
+    override fun onInterrupt() {}
+}

--- a/app/src/main/java/com/cicero/repostapp/TwitterAutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterAutopostFragment.kt
@@ -1,0 +1,126 @@
+package com.cicero.repostapp
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.io.File
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Fragment with a ViewPager that triggers Twitter autopost when button clicked.
+ */
+class TwitterAutopostFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_twitter_autopost, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val pager = view.findViewById<ViewPager2>(R.id.twitterViewPager)
+        pager.adapter = AutoPostPagerAdapter()
+    }
+
+    /** Adapter for ViewPager items. */
+    inner class AutoPostPagerAdapter : RecyclerView.Adapter<AutoPostPagerAdapter.VH>() {
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+            val v = layoutInflater.inflate(R.layout.item_twitter_autopost, parent, false)
+            return VH(v)
+        }
+        override fun getItemCount() = 1
+        override fun onBindViewHolder(holder: VH, position: Int) {}
+        inner class VH(val v: View) : RecyclerView.ViewHolder(v) {
+            init {
+                val btn = v.findViewById<Button>(R.id.btnPostToTwitter)
+                btn.setOnClickListener {
+                    lifecycleScope.launch(Dispatchers.IO) { performTwitterPost() }
+                }
+            }
+        }
+    }
+
+    /** Data representation of Instagram post. */
+    data class InstaPost(val id: String, val caption: String, val imageUrl: String, val timestamp: Long)
+
+    /** Fetch latest post from official Instagram page. */
+    private fun fetchLatestPost(username: String): InstaPost? {
+        val url = "https://www.instagram.com/$username/?__a=1&__d=dis"
+        val client = OkHttpClient()
+        val request = Request.Builder().url(url).build()
+        return try {
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) return null
+                val body = resp.body?.string() ?: return null
+                val obj = JSONObject(body)
+                val node = obj.optJSONObject("graphql")
+                    ?.optJSONObject("user")
+                    ?.optJSONObject("edge_owner_to_timeline_media")
+                    ?.optJSONArray("edges")?.optJSONObject(0)?.optJSONObject("node")
+                    ?: return null
+                val ts = node.optLong("taken_at_timestamp")
+                val caption = node.optJSONObject("edge_media_to_caption")
+                    ?.optJSONArray("edges")?.optJSONObject(0)?.optJSONObject("node")
+                    ?.optString("text") ?: ""
+                val img = node.optString("display_url")
+                val id = node.optString("id")
+                InstaPost(id, caption, img, ts)
+            }
+        } catch (_: Exception) { null }
+    }
+
+    /** Ensure the post image is downloaded and return the file path. */
+    private fun ensureDownloaded(post: InstaPost): File? {
+        val dir = File(requireContext().getExternalFilesDir(null), "OfficialPosts")
+        if (!dir.exists()) dir.mkdirs()
+        val out = File(dir, post.id + ".jpg")
+        if (out.exists()) return out
+        val client = OkHttpClient()
+        val req = Request.Builder().url(post.imageUrl).build()
+        return try {
+            client.newCall(req).execute().use { resp ->
+                if (!resp.isSuccessful) return null
+                resp.body?.byteStream()?.use { input ->
+                    out.outputStream().use { input.copyTo(it) }
+                }
+                out
+            }
+        } catch (_: Exception) { null }
+    }
+
+    private suspend fun performTwitterPost() {
+        val post = fetchLatestPost("instagram") ?: return
+        val postDate = Instant.ofEpochSecond(post.timestamp)
+            .atZone(ZoneId.systemDefault()).toLocalDate()
+        if (postDate != LocalDate.now()) return // no post today
+        val file = ensureDownloaded(post) ?: return
+        val prefs = requireContext().getSharedPreferences("twitter_post_prefs", Context.MODE_PRIVATE)
+        prefs.edit().putString("twitter_post_text", post.caption)
+            .putString("twitter_post_image", file.absolutePath).apply()
+        withContext(Dispatchers.Main) {
+            val intent = requireContext().packageManager.getLaunchIntentForPackage("com.twitter.android")
+            if (intent != null) startActivity(intent) else {
+                android.widget.Toast.makeText(requireContext(), "Twitter not installed", android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_twitter_autopost.xml
+++ b/app/src/main/res/layout/fragment_twitter_autopost.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/twitterViewPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/item_twitter_autopost.xml
+++ b/app/src/main/res/layout/item_twitter_autopost.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/btnPostToTwitter"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Twitter Post" />
+
+</FrameLayout>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:packageNames="com.twitter.android"
+    android:notificationTimeout="100" />


### PR DESCRIPTION
## Summary
- add a fragment with ViewPager item to trigger Twitter autopost
- create accessibility service to automate composing a tweet
- configure the service in `AndroidManifest.xml`
- add required XML layouts and service config

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884af5065d08327bb1adaa86b1ba57d