### PR TITLE
Add Twitter autopost page in dashboard

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
@@ -9,6 +9,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import android.view.Menu
 import android.view.MenuItem
+import com.cicero.repostapp.TwitterAutopostFragment
 
 class DashboardActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,7 +18,13 @@ class DashboardActivity : AppCompatActivity() {
         supportActionBar?.setDisplayShowHomeEnabled(true)
         supportActionBar?.setLogo(R.mipmap.ic_launcher_foreground)
         supportActionBar?.setDisplayUseLogoEnabled(true)
-        val pageTitles = listOf("Profil", "Tugas Resmi", "Tugas Khusus", "Autorepost")
+        val pageTitles = listOf(
+            "Profil",
+            "Tugas Resmi",
+            "Tugas Khusus",
+            "Autorepost",
+            "Tw Autopost"
+        )
 
         val token = intent.getStringExtra("token")
         val userId = intent.getStringExtra("userId")
@@ -26,7 +33,8 @@ class DashboardActivity : AppCompatActivity() {
             UserProfileFragment.newInstance(userId, token),
             DashboardFragment.newInstance(userId, token),
             SpecialTaskFragment.newInstance(userId, token),
-            AutopostFragment.newInstance()
+            AutopostFragment.newInstance(),
+            TwitterAutopostFragment()
         )
 
         val viewPager = findViewById<ViewPager2>(R.id.view_pager)
@@ -45,6 +53,7 @@ class DashboardActivity : AppCompatActivity() {
                 R.id.nav_insta -> { viewPager.currentItem = 1; true }
                 R.id.nav_special -> { viewPager.currentItem = 2; true }
                 R.id.nav_autopost -> { viewPager.currentItem = 3; true }
+                R.id.nav_autopost_twitter -> { viewPager.currentItem = 4; true }
                 else -> false
             }
         }
@@ -56,6 +65,7 @@ class DashboardActivity : AppCompatActivity() {
                     1 -> { bottomNav.selectedItemId = R.id.nav_insta }
                     2 -> { bottomNav.selectedItemId = R.id.nav_special }
                     3 -> { bottomNav.selectedItemId = R.id.nav_autopost }
+                    4 -> { bottomNav.selectedItemId = R.id.nav_autopost_twitter }
                 }
                 supportActionBar?.title = pageTitles[position]
             }

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -16,5 +16,9 @@
         android:id="@+id/nav_autopost"
         android:icon="@android:drawable/ic_menu_upload"
         android:title="Autopost" />
+    <item
+        android:id="@+id/nav_autopost_twitter"
+        android:icon="@drawable/ic_twitter"
+        android:title="Twitter Autopost" />
     <!-- Removed YouTube and Facebook pages -->
 </menu>


### PR DESCRIPTION
## Summary
- include Twitter autopost page in ViewPager
- expose new bottom navigation item for Twitter autopost

## Testing
- `./gradlew --stacktrace assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ba3bbf1083278defcbc91f0e9c0c