### PR TITLE
Add console log output to Twitter autopost page

### DIFF
--- a/app/src/main/res/layout/item_twitter_autopost.xml
+++ b/app/src/main/res/layout/item_twitter_autopost.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp">
@@ -10,4 +11,18 @@
         android:layout_height="wrap_content"
         android:text="Twitter Post" />
 
-</FrameLayout>
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:overScrollMode="always">
+
+        <TextView
+            android:id="@+id/txtConsoleLogs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textIsSelectable="true" />
+    </ScrollView>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add a text view inside the Twitter autopost pager item
- capture the text view and log messages from `performTwitterPost`

## Testing
- `./gradlew test --no-daemon` *(fails: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6885c6aef06c83279b8db98d62938258