### PR TITLE
Add share sheet automation for Twitter autopost

### DIFF
--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -2,5 +2,4 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:packageNames="com.twitter.android"
     android:notificationTimeout="100" />


### PR DESCRIPTION
## Summary
- relax accessibility service package filter
- handle Twitter share sheet by clicking "Ingat Pilihan saya" and choosing "Posting"

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68862990b83c8327bdc63b46c03d1c31