### PR TITLE
Add more debug logs to Twitter autopost service

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/TwitterAutoPostService.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterAutoPostService.kt
@@ -27,7 +27,10 @@ class TwitterAutoPostService : AccessibilityService() {
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
-        val root = rootInActiveWindow ?: return
+        val root = rootInActiveWindow ?: run {
+            Log.d(TAG, "No active window root")
+            return
+        }
 
         val remember = findFirstByText(root, "ingat pilihan saya")
         val shareTitle = findFirstByText(root, "bagikan")
@@ -45,6 +48,8 @@ class TwitterAutoPostService : AccessibilityService() {
                 }
                 clickScheduled = false
             }, 1000)
+        } else if (!clickScheduled) {
+            Log.d(TAG, "Share sheet texts not found")
         }
     }
 


### PR DESCRIPTION
## Summary
- add logging when the service can't find the active window
- log when share sheet text nodes are missing

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886494395a88327a97496d2700b0e18