### PR TITLE
Integrate AutoPost accessibility service

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ npm start
 The server listens on port `3000` by default, so you can access the page at
 `http://localhost:3000/autopost` once it is running.
 
+### AutoPost Accessibility Service
+
+The Android app ships with an accessibility service that can automatically
+press the **Posting** button on the Twitter share screen. The behaviour is
+configured through `AutoPostRule` objects which are loaded from shared
+preferences. A default rule for Twitter is bundled with the app. To enable the
+service open **Settings → Accessibility → Cicero Reposter – AutoPost**.
+
 
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,17 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_service_config" />
         </service>
+        <service
+            android:name=".AutoPostAccessibilityService"
+            android:exported="false"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
         <!-- Autopost functionality handled outside of accessibility services -->
     </application>
 </manifest>


### PR DESCRIPTION
## Summary
- register `AutoPostAccessibilityService` in the manifest
- document usage of the new accessibility service in README

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886cbfc96b48327a64895482219492f