### PR TITLE
Fix duplicate node helper definitions

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
@@ -6,8 +6,9 @@ import android.os.SystemClock
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import java.text.Normalizer
-import java.util.Locale
+import com.cicero.repostapp.util.containsAllTexts
+import com.cicero.repostapp.util.findNodesByText
+import com.cicero.repostapp.util.safeClick
 
 /**
  * AutoPostAccessibilityService helps automatically press the posting button on
@@ -60,43 +61,6 @@ class AutoPostAccessibilityService : AccessibilityService() {
     }
 }
 
-/** Recursively search node tree for text matches. */
-fun findNodesByText(root: AccessibilityNodeInfo?, text: String, maxDepth: Int = Int.MAX_VALUE): List<AccessibilityNodeInfo> {
-    if (root == null) return emptyList()
-    val normalized = text.normalize()
-    val result = mutableListOf<AccessibilityNodeInfo>()
-    fun traverse(node: AccessibilityNodeInfo?, depth: Int) {
-        if (node == null || depth > maxDepth) return
-        val nodeText = node.text?.toString() ?: node.contentDescription?.toString()
-        if (nodeText?.normalize()?.contains(normalized) == true) {
-            result.add(node)
-        }
-        for (i in 0 until node.childCount) {
-            traverse(node.getChild(i), depth + 1)
-        }
-    }
-    traverse(root, 0)
-    return result
-}
-
-/** Check that every text is present somewhere in the tree. */
-fun containsAllTexts(root: AccessibilityNodeInfo?, texts: List<String>, maxDepth: Int = Int.MAX_VALUE): Boolean {
-    return texts.all { findNodesByText(root, it, maxDepth).isNotEmpty() }
-}
-
-/** Perform safe click on visible, enabled node. */
-fun safeClick(node: AccessibilityNodeInfo?): Boolean {
-    if (node == null || !node.isVisibleToUser || !node.isEnabled) return false
-    return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-}
-
-/** Normalize string for comparison (lowercase, trim, remove diacritics). */
-fun String.normalize(): String = Normalizer.normalize(this, Normalizer.Form.NFD)
-    .lowercase(Locale.ROOT)
-    .trim()
-    .replace(Regex("\\p{Mn}+"), "")
-
-/*
  To add a new rule (e.g. Instagram or TikTok),
  add an entry with the same fields in AutoPostRuleLoader.defaultRulesJson
  or save a JSON array under SharedPreferences key "rules_json".

--- a/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
@@ -6,8 +6,9 @@ import android.os.SystemClock
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import java.text.Normalizer
-import java.util.Locale
+import com.cicero.repostapp.util.containsAllTexts
+import com.cicero.repostapp.util.findNodesByText
+import com.cicero.repostapp.util.safeClick
 
 /**
  * AutoPostAccessibilityService helps automatically press the posting button on
@@ -60,43 +61,6 @@ class AutoPostSpecialAccessibilityService : AccessibilityService() {
     }
 }
 
-/** Recursively search node tree for text matches. */
-fun findNodesByText(root: AccessibilityNodeInfo?, text: String, maxDepth: Int = Int.MAX_VALUE): List<AccessibilityNodeInfo> {
-    if (root == null) return emptyList()
-    val normalized = text.normalize()
-    val result = mutableListOf<AccessibilityNodeInfo>()
-    fun traverse(node: AccessibilityNodeInfo?, depth: Int) {
-        if (node == null || depth > maxDepth) return
-        val nodeText = node.text?.toString() ?: node.contentDescription?.toString()
-        if (nodeText?.normalize()?.contains(normalized) == true) {
-            result.add(node)
-        }
-        for (i in 0 until node.childCount) {
-            traverse(node.getChild(i), depth + 1)
-        }
-    }
-    traverse(root, 0)
-    return result
-}
-
-/** Check that every text is present somewhere in the tree. */
-fun containsAllTexts(root: AccessibilityNodeInfo?, texts: List<String>, maxDepth: Int = Int.MAX_VALUE): Boolean {
-    return texts.all { findNodesByText(root, it, maxDepth).isNotEmpty() }
-}
-
-/** Perform safe click on visible, enabled node. */
-fun safeClick(node: AccessibilityNodeInfo?): Boolean {
-    if (node == null || !node.isVisibleToUser || !node.isEnabled) return false
-    return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-}
-
-/** Normalize string for comparison (lowercase, trim, remove diacritics). */
-fun String.normalize(): String = Normalizer.normalize(this, Normalizer.Form.NFD)
-    .lowercase(Locale.ROOT)
-    .trim()
-    .replace(Regex("\\p{Mn}+"), "")
-
-/*
  To add a new rule (e.g. Instagram or TikTok),
  add an entry with the same fields in AutoPostRuleLoader.defaultRulesJson
  or save a JSON array under SharedPreferences key "rules_json".

--- a/app/src/main/java/com/cicero/repostapp/util/NodeTreeUtils.kt
+++ b/app/src/main/java/com/cicero/repostapp/util/NodeTreeUtils.kt
@@ -1,0 +1,41 @@
+package com.cicero.repostapp.util
+
+import android.view.accessibility.AccessibilityNodeInfo
+import java.text.Normalizer
+import java.util.Locale
+
+/** Recursively search node tree for text matches. */
+fun findNodesByText(root: AccessibilityNodeInfo?, text: String, maxDepth: Int = Int.MAX_VALUE): List<AccessibilityNodeInfo> {
+    if (root == null) return emptyList()
+    val normalized = text.normalize()
+    val result = mutableListOf<AccessibilityNodeInfo>()
+    fun traverse(node: AccessibilityNodeInfo?, depth: Int) {
+        if (node == null || depth > maxDepth) return
+        val nodeText = node.text?.toString() ?: node.contentDescription?.toString()
+        if (nodeText?.normalize()?.contains(normalized) == true) {
+            result.add(node)
+        }
+        for (i in 0 until node.childCount) {
+            traverse(node.getChild(i), depth + 1)
+        }
+    }
+    traverse(root, 0)
+    return result
+}
+
+/** Check that every text is present somewhere in the tree. */
+fun containsAllTexts(root: AccessibilityNodeInfo?, texts: List<String>, maxDepth: Int = Int.MAX_VALUE): Boolean {
+    return texts.all { findNodesByText(root, it, maxDepth).isNotEmpty() }
+}
+
+/** Perform safe click on visible, enabled node. */
+fun safeClick(node: AccessibilityNodeInfo?): Boolean {
+    if (node == null || !node.isVisibleToUser || !node.isEnabled) return false
+    return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+}
+
+/** Normalize string for comparison (lowercase, trim, remove diacritics). */
+fun String.normalize(): String = Normalizer.normalize(this, Normalizer.Form.NFD)
+    .lowercase(Locale.ROOT)
+    .trim()
+    .replace(Regex("\\p{Mn}+"), "")


### PR DESCRIPTION
## Summary
- avoid conflicting overloads by extracting node helper extensions

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68871ef4009083278839ce3161a07744