### PR TITLE
Fix duplicate accessibility helpers

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AccessibilityNodeUtils.kt
+++ b/app/src/main/java/com/cicero/repostapp/AccessibilityNodeUtils.kt
@@ -1,0 +1,43 @@
+package com.cicero.repostapp
+
+import android.view.accessibility.AccessibilityNodeInfo
+import java.text.Normalizer
+import java.util.Locale
+
+/** Utility functions for working with AccessibilityNodeInfo trees. */
+
+/** Recursively search node tree for text matches. */
+fun findNodesByText(root: AccessibilityNodeInfo?, text: String, maxDepth: Int = Int.MAX_VALUE): List<AccessibilityNodeInfo> {
+    if (root == null) return emptyList()
+    val normalized = text.normalize()
+    val result = mutableListOf<AccessibilityNodeInfo>()
+    fun traverse(node: AccessibilityNodeInfo?, depth: Int) {
+        if (node == null || depth > maxDepth) return
+        val nodeText = node.text?.toString() ?: node.contentDescription?.toString()
+        if (nodeText?.normalize()?.contains(normalized) == true) {
+            result.add(node)
+        }
+        for (i in 0 until node.childCount) {
+            traverse(node.getChild(i), depth + 1)
+        }
+    }
+    traverse(root, 0)
+    return result
+}
+
+/** Check that every text is present somewhere in the tree. */
+fun containsAllTexts(root: AccessibilityNodeInfo?, texts: List<String>, maxDepth: Int = Int.MAX_VALUE): Boolean {
+    return texts.all { findNodesByText(root, it, maxDepth).isNotEmpty() }
+}
+
+/** Perform safe click on visible, enabled node. */
+fun safeClick(node: AccessibilityNodeInfo?): Boolean {
+    if (node == null || !node.isVisibleToUser || !node.isEnabled) return false
+    return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+}
+
+/** Normalize string for comparison (lowercase, trim, remove diacritics). */
+fun String.normalize(): String = Normalizer.normalize(this, Normalizer.Form.NFD)
+    .lowercase(Locale.ROOT)
+    .trim()
+    .replace(Regex("\\p{Mn}+"), "")

--- a/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
@@ -6,8 +6,6 @@ import android.os.SystemClock
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import java.text.Normalizer
-import java.util.Locale
 
 /**
  * AutoPostAccessibilityService helps automatically press the posting button on
@@ -60,41 +58,6 @@ class AutoPostAccessibilityService : AccessibilityService() {
     }
 }
 
-/** Recursively search node tree for text matches. */
-fun findNodesByText(root: AccessibilityNodeInfo?, text: String, maxDepth: Int = Int.MAX_VALUE): List<AccessibilityNodeInfo> {
-    if (root == null) return emptyList()
-    val normalized = text.normalize()
-    val result = mutableListOf<AccessibilityNodeInfo>()
-    fun traverse(node: AccessibilityNodeInfo?, depth: Int) {
-        if (node == null || depth > maxDepth) return
-        val nodeText = node.text?.toString() ?: node.contentDescription?.toString()
-        if (nodeText?.normalize()?.contains(normalized) == true) {
-            result.add(node)
-        }
-        for (i in 0 until node.childCount) {
-            traverse(node.getChild(i), depth + 1)
-        }
-    }
-    traverse(root, 0)
-    return result
-}
-
-/** Check that every text is present somewhere in the tree. */
-fun containsAllTexts(root: AccessibilityNodeInfo?, texts: List<String>, maxDepth: Int = Int.MAX_VALUE): Boolean {
-    return texts.all { findNodesByText(root, it, maxDepth).isNotEmpty() }
-}
-
-/** Perform safe click on visible, enabled node. */
-fun safeClick(node: AccessibilityNodeInfo?): Boolean {
-    if (node == null || !node.isVisibleToUser || !node.isEnabled) return false
-    return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-}
-
-/** Normalize string for comparison (lowercase, trim, remove diacritics). */
-fun String.normalize(): String = Normalizer.normalize(this, Normalizer.Form.NFD)
-    .lowercase(Locale.ROOT)
-    .trim()
-    .replace(Regex("\\p{Mn}+"), "")
 
 /*
  To add a new rule (e.g. Instagram or TikTok),

--- a/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
@@ -6,8 +6,6 @@ import android.os.SystemClock
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import java.text.Normalizer
-import java.util.Locale
 
 /**
  * AutoPostAccessibilityService helps automatically press the posting button on
@@ -60,41 +58,6 @@ class AutoPostSpecialAccessibilityService : AccessibilityService() {
     }
 }
 
-/** Recursively search node tree for text matches. */
-fun findNodesByText(root: AccessibilityNodeInfo?, text: String, maxDepth: Int = Int.MAX_VALUE): List<AccessibilityNodeInfo> {
-    if (root == null) return emptyList()
-    val normalized = text.normalize()
-    val result = mutableListOf<AccessibilityNodeInfo>()
-    fun traverse(node: AccessibilityNodeInfo?, depth: Int) {
-        if (node == null || depth > maxDepth) return
-        val nodeText = node.text?.toString() ?: node.contentDescription?.toString()
-        if (nodeText?.normalize()?.contains(normalized) == true) {
-            result.add(node)
-        }
-        for (i in 0 until node.childCount) {
-            traverse(node.getChild(i), depth + 1)
-        }
-    }
-    traverse(root, 0)
-    return result
-}
-
-/** Check that every text is present somewhere in the tree. */
-fun containsAllTexts(root: AccessibilityNodeInfo?, texts: List<String>, maxDepth: Int = Int.MAX_VALUE): Boolean {
-    return texts.all { findNodesByText(root, it, maxDepth).isNotEmpty() }
-}
-
-/** Perform safe click on visible, enabled node. */
-fun safeClick(node: AccessibilityNodeInfo?): Boolean {
-    if (node == null || !node.isVisibleToUser || !node.isEnabled) return false
-    return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-}
-
-/** Normalize string for comparison (lowercase, trim, remove diacritics). */
-fun String.normalize(): String = Normalizer.normalize(this, Normalizer.Form.NFD)
-    .lowercase(Locale.ROOT)
-    .trim()
-    .replace(Regex("\\p{Mn}+"), "")
 
 /*
  To add a new rule (e.g. Instagram or TikTok),


### PR DESCRIPTION
## Summary
- create `AccessibilityNodeUtils` to hold shared functions
- remove duplicate helper functions from service classes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68871f00b57c832794ec03d28b9590a1