### PR TITLE
Fix stray comment in accessibility services

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
@@ -61,8 +61,9 @@ class AutoPostAccessibilityService : AccessibilityService() {
     }
 }
 
+/*
  To add a new rule (e.g. Instagram or TikTok),
  add an entry with the same fields in AutoPostRuleLoader.defaultRulesJson
  or save a JSON array under SharedPreferences key "rules_json".
-*/
+ */
 

--- a/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
@@ -61,8 +61,9 @@ class AutoPostSpecialAccessibilityService : AccessibilityService() {
     }
 }
 
+/*
  To add a new rule (e.g. Instagram or TikTok),
  add an entry with the same fields in AutoPostRuleLoader.defaultRulesJson
  or save a JSON array under SharedPreferences key "rules_json".
-*/
+ */
 


### PR DESCRIPTION
## Summary
- wrap trailing notes in block comments

## Testing
- `./gradlew -version`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887208ac9708327a0b0387edb6daf0f