### PR TITLE
Fix autopost rule for Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,12 @@ The server listens on port `3000` by default, so you can access the page at
 The Android app ships with an accessibility service that can automatically
 press the **Posting** button on the Twitter share screen. The behaviour is
 configured through `AutoPostRule` objects which are loaded from shared
-preferences. A default rule for Twitter is bundled with the app. To enable the
-service open **Settings → Accessibility → Cicero Reposter – AutoPost**.
+preferences. A default rule for Twitter is bundled with the app. To use the
+feature make sure the service is enabled under **Settings → Accessibility →
+Cicero Reposter – AutoPost**.  If the button text in the Twitter composer has
+changed (for example displaying *Tweet* instead of *Posting*) adjust the rule in
+`AutoPostRule.kt` or provide a custom rule via shared preferences so the
+service can recognise the new label.
 
 
 

--- a/app/src/main/java/com/cicero/repostapp/AutoPostRule.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostRule.kt
@@ -23,8 +23,15 @@ object AutoPostRuleLoader {
         [
           {
             "packageName": "com.twitter.android",
-            "requiresAll": ["ingat pilihan saya", "bagikan", "posting"],
+            "requiresAll": ["posting"],
             "clickTargetText": "posting",
+            "maxDepth": 5,
+            "cooldownMs": 1500
+          },
+          {
+            "packageName": "com.twitter.android",
+            "requiresAll": ["tweet"],
+            "clickTargetText": "tweet",
             "maxDepth": 5,
             "cooldownMs": 1500
           }


### PR DESCRIPTION
## Summary
- extend `AutoPostRule` defaults to recognise `Posting` or `Tweet`
- clarify enabling and customising the AutoPost accessibility service in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68872801a55483279095b652a8f8ebb6