### PR TITLE
Improve share sheet interaction

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
@@ -3,12 +3,16 @@ package com.cicero.repostapp
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.os.SystemClock
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import com.cicero.repostapp.util.containsAllTexts
 import com.cicero.repostapp.util.findNodesByText
 import com.cicero.repostapp.util.safeClick
+import com.cicero.repostapp.util.traverseParentToFindClickable
+import com.cicero.repostapp.util.logNodeTree
 
 /**
  * AutoPostAccessibilityService helps automatically press the posting button on
@@ -35,6 +39,13 @@ class AutoPostSpecialAccessibilityService : AccessibilityService() {
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
+        val root = rootInActiveWindow ?: return
+
+        if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED ||
+            event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED) {
+            handleShareSheet(root)
+        }
+
         val source = event.source ?: return
         val pkg = event.packageName?.toString() ?: return
         val rule = rules.firstOrNull { it.packageName == pkg } ?: return
@@ -44,7 +55,6 @@ class AutoPostSpecialAccessibilityService : AccessibilityService() {
         val last = lastExecution[pkg] ?: 0L
         if (now - last < rule.cooldownMs) return
 
-        val root = rootInActiveWindow ?: return
         if (!containsAllTexts(root, rule.requiresAll, rule.maxDepth)) return
 
         val targets = findNodesByText(root, rule.clickTargetText, rule.maxDepth)
@@ -52,6 +62,22 @@ class AutoPostSpecialAccessibilityService : AccessibilityService() {
             log("Clicked target for $pkg")
             lastExecution[pkg] = now
         }
+    }
+
+    private fun handleShareSheet(root: AccessibilityNodeInfo) {
+        val keywords = listOf("Copy link", "Salin tautan", "Twitter", "YouTube")
+        val matches = keywords.flatMap { findNodesByText(root, it, 8) }
+        if (matches.isEmpty()) return
+
+        if (BuildConfig.DEBUG) logNodeTree(root)
+
+        val target = matches.first().traverseParentToFindClickable() ?: return
+        Handler(Looper.getMainLooper()).postDelayed({
+            if (!target.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
+                target.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
+                target.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+            }
+        }, 300)
     }
 
     override fun onInterrupt() {}

--- a/app/src/main/java/com/cicero/repostapp/util/NodeTreeUtils.kt
+++ b/app/src/main/java/com/cicero/repostapp/util/NodeTreeUtils.kt
@@ -1,6 +1,7 @@
 package com.cicero.repostapp.util
 
 import android.view.accessibility.AccessibilityNodeInfo
+import android.util.Log
 import java.text.Normalizer
 import java.util.Locale
 
@@ -32,6 +33,26 @@ fun containsAllTexts(root: AccessibilityNodeInfo?, texts: List<String>, maxDepth
 fun safeClick(node: AccessibilityNodeInfo?): Boolean {
     if (node == null || !node.isVisibleToUser || !node.isEnabled) return false
     return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+}
+
+/** Traverse up the parent chain to find a clickable node. */
+fun AccessibilityNodeInfo.traverseParentToFindClickable(): AccessibilityNodeInfo? {
+    var current: AccessibilityNodeInfo? = this
+    while (current != null && !current.isClickable) {
+        current = current.parent
+    }
+    return current
+}
+
+/** Debug helper to log the node tree structure. */
+fun logNodeTree(node: AccessibilityNodeInfo?, depth: Int = 0) {
+    if (node == null) return
+    val indent = "  ".repeat(depth)
+    val text = node.text ?: node.contentDescription
+    Log.d("NodeTree", "$indent${node.className} text=$text clickable=${node.isClickable}")
+    for (i in 0 until node.childCount) {
+        logNodeTree(node.getChild(i), depth + 1)
+    }
 }
 
 /** Normalize string for comparison (lowercase, trim, remove diacritics). */


### PR DESCRIPTION
## Summary
- add helpers to traverse and log accessibility node tree
- add share sheet detection to AutoPost accessibility services
- click copy link or target app after share sheet appears

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68872d9430148327977fce0c452b73ac