### PR TITLE
Remove debug check for service logs

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
@@ -90,7 +90,7 @@ class AutoPostAccessibilityService : AccessibilityService() {
     override fun onInterrupt() {}
 
     private fun log(msg: String) {
-        if (BuildConfig.DEBUG) Log.d(TAG, msg)
+        Log.d(TAG, msg)
     }
 }
 

--- a/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostSpecialAccessibilityService.kt
@@ -90,7 +90,7 @@ class AutoPostSpecialAccessibilityService : AccessibilityService() {
     override fun onInterrupt() {}
 
     private fun log(msg: String) {
-        if (BuildConfig.DEBUG) Log.d(TAG, msg)
+        Log.d(TAG, msg)
     }
 }
 


### PR DESCRIPTION
## Summary
- always log `AutoPostAccessibilityService` events
- always log `AutoPostSpecialAccessibilityService` events

## Testing
- `./gradlew tasks --all`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68873dfb3f3c8327850089cbd4f53cb6