### PR TITLE
Improve autopost rule reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,17 @@ press the **Posting** button on the Twitter share screen. The behaviour is
 configured through `AutoPostRule` objects which are loaded from shared
 preferences. A default rule for Twitter is bundled with the app. To use the
 feature make sure the service is enabled under **Settings → Accessibility →
-Cicero Reposter – AutoPost**.  If the button text in the Twitter composer has
-changed (for example displaying *Tweet* instead of *Posting*) adjust the rule in
-`AutoPostRule.kt` or provide a custom rule via shared preferences so the
-service can recognise the new label.
+Cicero Reposter – AutoPost**.
+
+If the button text in the Twitter composer has changed (for example displaying
+*Tweet* instead of *Posting*) adjust the rule in `AutoPostRule.kt` or provide a
+custom JSON array under the `rules_json` key in shared preferences so the
+service can recognise the new label. After updating the preferences send the
+following broadcast to reload the rules without restarting the service:
+
+```bash
+adb shell am broadcast -a com.cicero.repostapp.RELOAD_RULES
+```
 
 
 

--- a/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutoPostAccessibilityService.kt
@@ -6,6 +6,10 @@ import android.os.SystemClock
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import com.cicero.repostapp.util.containsAllTexts
@@ -26,6 +30,16 @@ class AutoPostAccessibilityService : AccessibilityService() {
     private val TAG = "AutoPostService"
     private val lastExecution = mutableMapOf<String, Long>()
     private lateinit var rules: List<AutoPostRule>
+    private val reloadReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            rules = AutoPostRuleLoader.load(this@AutoPostAccessibilityService)
+            log("Rules reloaded")
+        }
+    }
+
+    companion object {
+        const val ACTION_RELOAD_RULES = "com.cicero.repostapp.RELOAD_RULES"
+    }
 
     override fun onServiceConnected() {
         serviceInfo = serviceInfo.apply {
@@ -35,6 +49,7 @@ class AutoPostAccessibilityService : AccessibilityService() {
             flags = AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
                     AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
         }
+        registerReceiver(reloadReceiver, IntentFilter(ACTION_RELOAD_RULES))
         rules = AutoPostRuleLoader.load(this)
     }
 
@@ -88,6 +103,11 @@ class AutoPostAccessibilityService : AccessibilityService() {
     }
 
     override fun onInterrupt() {}
+
+    override fun onDestroy() {
+        unregisterReceiver(reloadReceiver)
+        super.onDestroy()
+    }
 
     private fun log(msg: String) {
         Log.d(TAG, msg)


### PR DESCRIPTION
## Summary
- add broadcast receiver to reload AutoPost rules
- document reloading rules in the README

## Testing
- `./gradlew tasks`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874679d734832781232f30c7910876