### PR TITLE
Add env-based Twitter credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 TWITTER_CONSUMER_KEY=your_consumer_key
 TWITTER_CONSUMER_SECRET=your_consumer_secret
 TWITTER_CALLBACK_URL=repostapp-twitter://callback
+TWITTER_ACCESS_TOKEN=your_access_token
+TWITTER_ACCESS_SECRET=your_access_secret
 YOUTUBE_CLIENT_ID=your_youtube_client_id
 YOUTUBE_REDIRECT_URI=repostapp-youtube://oauth
 YOUTUBE_API_KEY=your_youtube_api_key

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,8 @@ android {
         buildConfigField("String", "TWITTER_CONSUMER_SECRET", "\"${env("TWITTER_CONSUMER_SECRET")}\"")
         val callback = env("TWITTER_CALLBACK_URL").ifEmpty { "repostapp-twitter://callback" }
         buildConfigField("String", "TWITTER_CALLBACK_URL", "\"$callback\"")
+        buildConfigField("String", "TWITTER_ACCESS_TOKEN", "\"${env("TWITTER_ACCESS_TOKEN")}\"")
+        buildConfigField("String", "TWITTER_ACCESS_SECRET", "\"${env("TWITTER_ACCESS_SECRET")}\"")
         buildConfigField("String", "YOUTUBE_CLIENT_ID", "\"${env("YOUTUBE_CLIENT_ID")}\"")
         val ytRedirect = env("YOUTUBE_REDIRECT_URI").ifEmpty { "repostapp-youtube://oauth" }
         buildConfigField("String", "YOUTUBE_REDIRECT_URI", "\"$ytRedirect\"")
@@ -74,6 +76,8 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.github.instagram4j:instagram4j:2.0.7")
     implementation("org.twitter4j:twitter4j-core:4.1.1")
+    implementation("com.github.scribejava:scribejava-core:8.3.3")
+    implementation("com.github.scribejava:scribejava-apis:8.3.3")
     // Align with the version pulled in by the Android Gradle plugin to avoid
     // dependency resolution conflicts during the build.
     compileOnly("com.google.errorprone:error_prone_annotations:2.15.0")

--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -34,6 +34,7 @@ import kotlin.coroutines.resume
 import twitter4j.TwitterFactory
 import twitter4j.auth.AccessToken
 import com.github.instagram4j.instagram4j.requests.feed.FeedUserRequest
+import com.cicero.repostapp.postTweetWithMedia
 
 class AutopostFragment : Fragment() {
 
@@ -204,6 +205,7 @@ class AutopostFragment : Fragment() {
         val tiktokCheck = view.findViewById<ImageView>(R.id.tiktok_check)
         val tiktokText = view.findViewById<TextView>(R.id.tiktok_username)
         val start = view.findViewById<Button>(R.id.button_start)
+        val postTwitter = view.findViewById<Button>(R.id.button_post_twitter)
 
         // attempt to load saved session
         lifecycleScope.launch(Dispatchers.IO) {
@@ -220,6 +222,16 @@ class AutopostFragment : Fragment() {
         start.setOnClickListener {
             lifecycleScope.launch(Dispatchers.IO) {
                 runAutopostWorkflow()
+            }
+        }
+        postTwitter.setOnClickListener {
+            lifecycleScope.launch(Dispatchers.IO) {
+                val file = java.io.File(requireContext().filesDir, "sample.jpg")
+                val ok = postTweetWithMedia("Hello from API", file)
+                withContext(Dispatchers.Main) {
+                    val msg = if (ok) "Tweet terkirim" else "Gagal mengirim tweet"
+                    android.widget.Toast.makeText(requireContext(), msg, android.widget.Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/cicero/repostapp/TwitterApiPoster.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterApiPoster.kt
@@ -1,0 +1,92 @@
+package com.cicero.repostapp
+
+import android.util.Log
+import com.github.scribejava.apis.TwitterApi
+import com.github.scribejava.core.builder.ServiceBuilder
+import com.github.scribejava.core.model.OAuth1AccessToken
+import com.github.scribejava.core.model.OAuthRequest
+import com.github.scribejava.core.model.Verb
+import com.github.scribejava.core.oauth.OAuth10aService
+import okhttp3.FormBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import org.json.JSONObject
+import java.io.File
+import com.cicero.repostapp.BuildConfig
+
+private val API_KEY get() = BuildConfig.TWITTER_CONSUMER_KEY
+private val API_SECRET get() = BuildConfig.TWITTER_CONSUMER_SECRET
+private val ACCESS_TOKEN get() = BuildConfig.TWITTER_ACCESS_TOKEN
+private val ACCESS_TOKEN_SECRET get() = BuildConfig.TWITTER_ACCESS_SECRET
+
+suspend fun postTweetWithMedia(tweetText: String, file: File): Boolean {
+    val tag = "TwitterApiPoster"
+    val service: OAuth10aService = ServiceBuilder(API_KEY)
+        .apiSecret(API_SECRET)
+        .build(TwitterApi.instance())
+    val token = OAuth1AccessToken(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+    val client = OkHttpClient()
+
+    Log.d(tag, "Uploading media…")
+    val mediaBody = MultipartBody.Builder()
+        .setType(MultipartBody.FORM)
+        .addFormDataPart(
+            "media",
+            file.name,
+            file.asRequestBody("application/octet-stream".toMediaType())
+        )
+        .build()
+
+    val uploadSig = OAuthRequest(Verb.POST, "https://upload.twitter.com/1.1/media/upload.json")
+    service.signRequest(token, uploadSig)
+    val uploadRequest = Request.Builder()
+        .url("https://upload.twitter.com/1.1/media/upload.json")
+        .header("Authorization", uploadSig.getHeaders()["Authorization"] ?: "")
+        .post(mediaBody)
+        .build()
+
+    val mediaId = client.newCall(uploadRequest).execute().use { resp ->
+        if (!resp.isSuccessful) {
+            Log.e(tag, "Upload failed: ${'$'}{resp.code}")
+            return false
+        }
+        val body = resp.body?.string() ?: ""
+        Log.d(tag, "Upload response: ${'$'}body")
+        JSONObject(body).optString("media_id_string")
+    }
+
+    if (mediaId.isBlank()) {
+        Log.e(tag, "No media id returned")
+        return false
+    }
+
+    Log.d(tag, "Posting tweet with media ${'$'}mediaId")
+    val formBody = FormBody.Builder()
+        .add("status", tweetText)
+        .add("media_ids", mediaId)
+        .build()
+
+    val tweetReq = OAuthRequest(Verb.POST, "https://api.twitter.com/1.1/statuses/update.json")
+    tweetReq.addBodyParameter("status", tweetText)
+    tweetReq.addBodyParameter("media_ids", mediaId)
+    service.signRequest(token, tweetReq)
+
+    val request = Request.Builder()
+        .url("https://api.twitter.com/1.1/statuses/update.json")
+        .header("Authorization", tweetReq.getHeaders()["Authorization"] ?: "")
+        .post(formBody)
+        .build()
+
+    return client.newCall(request).execute().use { resp ->
+        if (resp.isSuccessful) {
+            Log.d(tag, "Tweet posted successfully")
+            true
+        } else {
+            Log.e(tag, "Tweet failed: ${'$'}{resp.code}")
+            false
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_autopost.xml
+++ b/app/src/main/res/layout/fragment_autopost.xml
@@ -167,6 +167,19 @@
         android:textColor="#1f1f1f"
         android:background="@drawable/button_green" />
 
+        <Button
+        android:id="@+id/button_post_twitter"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginTop="12dp"
+        android:text="POST TWITTER"
+        android:textStyle="bold"
+        android:textAllCaps="true"
+        android:textColor="#1f1f1f"
+        android:background="@drawable/button_green" />
+
 
     </LinearLayout>
 


### PR DESCRIPTION
## Summary
- add access token and secret fields in `.env.example`
- expose new fields via `BuildConfig` in `build.gradle.kts`
- load Twitter API credentials from `BuildConfig` in `TwitterApiPoster`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878a93fbb483279a1402462baa957a