### PR TITLE
Add Premium Post page

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
@@ -19,6 +19,7 @@ class DashboardActivity : AppCompatActivity() {
         val pageTitles = listOf(
             "Profil",
             "Tugas Resmi",
+            "Premium Post",
             "Tugas Khusus",
             "Autorepost"
         )
@@ -29,6 +30,7 @@ class DashboardActivity : AppCompatActivity() {
         val fragments = listOf(
             UserProfileFragment.newInstance(userId, token),
             DashboardFragment.newInstance(userId, token),
+            PremiumPostFragment.newInstance(userId, token),
             SpecialTaskFragment.newInstance(userId, token),
             AutopostFragment.newInstance()
         )
@@ -47,8 +49,9 @@ class DashboardActivity : AppCompatActivity() {
             when (item.itemId) {
                 R.id.nav_profile -> { viewPager.currentItem = 0; true }
                 R.id.nav_insta -> { viewPager.currentItem = 1; true }
-                R.id.nav_special -> { viewPager.currentItem = 2; true }
-                R.id.nav_autopost -> { viewPager.currentItem = 3; true }
+                R.id.nav_premium -> { viewPager.currentItem = 2; true }
+                R.id.nav_special -> { viewPager.currentItem = 3; true }
+                R.id.nav_autopost -> { viewPager.currentItem = 4; true }
                 else -> false
             }
         }
@@ -58,8 +61,9 @@ class DashboardActivity : AppCompatActivity() {
                 when (position) {
                     0 -> { bottomNav.selectedItemId = R.id.nav_profile }
                     1 -> { bottomNav.selectedItemId = R.id.nav_insta }
-                    2 -> { bottomNav.selectedItemId = R.id.nav_special }
-                    3 -> { bottomNav.selectedItemId = R.id.nav_autopost }
+                    2 -> { bottomNav.selectedItemId = R.id.nav_premium }
+                    3 -> { bottomNav.selectedItemId = R.id.nav_special }
+                    4 -> { bottomNav.selectedItemId = R.id.nav_autopost }
                 }
                 supportActionBar?.title = pageTitles[position]
             }

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -28,7 +28,7 @@ import okhttp3.Request
 import org.json.JSONArray
 import org.json.JSONObject
 
-class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
+open class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
 
     companion object {
         private const val ARG_USER_ID = "userId"

--- a/app/src/main/java/com/cicero/repostapp/PremiumPostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumPostFragment.kt
@@ -1,0 +1,13 @@
+package com.cicero.repostapp
+
+import androidx.core.os.bundleOf
+
+class PremiumPostFragment : DashboardFragment() {
+    companion object {
+        fun newInstance(userId: String?, token: String?): PremiumPostFragment {
+            val frag = PremiumPostFragment()
+            frag.arguments = bundleOf("userId" to userId, "token" to token)
+            return frag
+        }
+    }
+}

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -9,6 +9,10 @@
         android:icon="@android:drawable/ic_menu_gallery"
         android:title="Tugas Resmi" />
     <item
+        android:id="@+id/nav_premium"
+        android:icon="@android:drawable/ic_menu_gallery"
+        android:title="Premium Post" />
+    <item
         android:id="@+id/nav_special"
         android:icon="@android:drawable/ic_menu_agenda"
         android:title="Tugas Khusus" />


### PR DESCRIPTION
## Summary
- extend `DashboardFragment` to be open
- create `PremiumPostFragment` for premium posts
- include the premium page in `DashboardActivity`
- add Premium Post item to bottom navigation

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68886af1a52483278fc75f565bc542b3