### PR TITLE
Update premium share intents

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -381,7 +381,7 @@ open class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         }
     }
 
-    private fun sharePost(post: InstaPost) {
+    protected open fun sharePost(post: InstaPost, packageName: String? = null) {
         val fileName = post.id + if (post.isVideo) ".mp4" else ".jpg"
         val baseDir = java.io.File(requireContext().getExternalFilesDir(null), "CiceroReposterApp")
         if (!baseDir.exists()) baseDir.mkdirs()
@@ -436,12 +436,19 @@ open class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         if (!post.caption.isNullOrBlank()) {
             intent.putExtra(Intent.EXTRA_TEXT, post.caption)
         }
+        if (packageName != null) {
+            intent.setPackage(packageName)
+        }
         val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         clipboard.setPrimaryClip(ClipData.newPlainText("caption", post.caption ?: ""))
-        startActivity(Intent.createChooser(intent, "Share via"))
+        try {
+            startActivity(intent)
+        } catch (_: Exception) {
+            startActivity(Intent.createChooser(intent, "Share via"))
+        }
     }
 
-    private fun showShareDialog(post: InstaPost) {
+    protected open fun showShareDialog(post: InstaPost) {
         val opts = if (post.reported) {
             arrayOf("Share", "Kirim Link", "Laporan WhatsApp")
         } else {

--- a/app/src/main/java/com/cicero/repostapp/PremiumPostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumPostFragment.kt
@@ -10,4 +10,24 @@ class PremiumPostFragment : DashboardFragment() {
             return frag
         }
     }
+
+    override fun showShareDialog(post: InstaPost) {
+        val options = mutableListOf("Instagram", "Facebook", "Twitter", "TikTok")
+        if (post.isVideo) {
+            options.add("YouTube")
+        }
+        androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setItems(options.toTypedArray()) { _, which ->
+                val pkg = when (options[which]) {
+                    "Instagram" -> "com.instagram.android"
+                    "Facebook" -> "com.facebook.katana"
+                    "Twitter" -> "com.twitter.android"
+                    "TikTok" -> "com.zhiliaoapp.musically"
+                    "YouTube" -> "com.google.android.youtube"
+                    else -> null
+                }
+                sharePost(post, pkg)
+            }
+            .show()
+    }
 }


### PR DESCRIPTION
## Summary
- expose `sharePost` and `showShareDialog` so they can be overridden
- override `showShareDialog` in `PremiumPostFragment`
- allow sharing directly to Instagram, Facebook, Twitter, TikTok, and YouTube on premium posts

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ae7516788327a8a834805dfd9b4e