### PR TITLE
Add Instagram share progress dialog

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/PremiumPostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumPostFragment.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.widget.Toast
+import android.widget.TextView
 
 class PremiumPostFragment : DashboardFragment() {
     companion object {
@@ -36,17 +37,30 @@ class PremiumPostFragment : DashboardFragment() {
     }
 
     private fun shareViaInstagram(post: InstaPost) {
+        val view = layoutInflater.inflate(R.layout.dialog_progress, null)
+        val progressText = view.findViewById<TextView>(R.id.text_progress)
+        progressText.text = "Menyiapkan..."
+        val dialog = androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setView(view)
+            .setCancelable(false)
+            .create()
+        dialog.show()
+
         viewLifecycleOwner.lifecycleScope.launch {
+            progressText.text = "Memuat sesi..."
             val client = withContext(Dispatchers.IO) {
                 InstagramShareHelper.loadClient(requireContext())
             }
             if (client == null) {
+                dialog.dismiss()
                 Toast.makeText(requireContext(), "Autopost Instagram belum login", Toast.LENGTH_SHORT).show()
                 return@launch
             }
+            progressText.text = "Mengunggah..."
             val link = withContext(Dispatchers.IO) {
                 InstagramShareHelper.uploadPost(requireContext(), client, post)
             }
+            dialog.dismiss()
             if (link != null) {
                 Toast.makeText(requireContext(), "Berhasil upload", Toast.LENGTH_SHORT).show()
             } else {

--- a/app/src/main/res/layout/dialog_progress.xml
+++ b/app/src/main/res/layout/dialog_progress.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
+    <TextView
+        android:id="@+id/text_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="12dp"
+        android:text="Loading..."
+        android:textAlignment="center" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add dialog_progress layout
- show progress dialog and text while uploading instagram post in PremiumPostFragment

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b7fd47f08327be4226c12d4f556f