### PR TITLE
Fix Twitter posting to use v1.1 endpoints

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/TwitterApiPoster.kt
+++ b/app/src/main/java/com/cicero/repostapp/TwitterApiPoster.kt
@@ -23,6 +23,8 @@ suspend fun postTweetWithMedia(tweetText: String, file: File): Boolean {
         .setOAuthConsumerSecret(API_SECRET)
         .setOAuthAccessToken(ACCESS_TOKEN)
         .setOAuthAccessTokenSecret(ACCESS_TOKEN_SECRET)
+        .setRestBaseURL("https://api.twitter.com/1.1/")
+        .setUploadBaseURL("https://upload.twitter.com/1.1/")
     val twitter = TwitterFactory(cb.build()).instance
 
     return try {
@@ -48,6 +50,8 @@ suspend fun postTweetWithMediaResponse(tweetText: String, file: File): TwitterPo
         .setOAuthAccessToken(ACCESS_TOKEN)
         .setOAuthAccessTokenSecret(ACCESS_TOKEN_SECRET)
         .setJSONStoreEnabled(true)
+        .setRestBaseURL("https://api.twitter.com/1.1/")
+        .setUploadBaseURL("https://upload.twitter.com/1.1/")
     val twitter = TwitterFactory(cb.build()).instance
 
     return try {


### PR DESCRIPTION
## Summary
- specify Twitter API v1.1 endpoints when posting a tweet with twitter4j

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_6888df9c4ad8832782b9a776aa4d8e08