### PR TITLE
Handle autopost failures per task

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -940,12 +940,18 @@ class AutopostFragment : Fragment() {
             appendLog("Memproses tugas ${'$'}{post.taskNumber} (${ '$'}{post.id })")
             appendLog("Memeriksa download…")
             delay(5000)
-            val file = retryAction("download konten") { downloadIfNeeded(post) } ?: break
+            val file = retryAction("download konten") { downloadIfNeeded(post) } ?: run {
+                appendLog("Lewati tugas karena gagal mengunduh konten")
+                continue
+            }
             if (!post.isVideo && post.isCarousel) {
                 downloadCarouselImagesIfNeeded(post)
             }
             delay(5000)
-            val igLink = retryAction("upload Instagram") { uploadToInstagram(post, file) } ?: break
+            val igLink = retryAction("upload Instagram") { uploadToInstagram(post, file) } ?: run {
+                appendLog("Lewati tugas karena gagal mengunggah ke Instagram")
+                continue
+            }
             delay(5000)
             appendLog("Link: ${'$'}igLink")
             sendLink(post.id, igLink)

--- a/docs/manual-qa/autopost-retry.md
+++ b/docs/manual-qa/autopost-retry.md
@@ -1,0 +1,21 @@
+# Autopost retry skip verification
+
+These steps confirm that a failure in one task no longer stops the rest of the autopost queue.
+
+## Prerequisites
+- A build that includes the updated retry handling (May 2024 or later).
+- At least two autopost tasks available for the authenticated account.
+- Ability to toggle the device's network connection.
+
+## Steps
+1. Launch the app and navigate to the Autopost screen.
+2. Begin the autopost workflow.
+3. As soon as the first task reaches the "Mengunduh konten…" step, disable all network connectivity (Wi‑Fi and cellular).
+4. Wait for the three retry attempts to finish and observe the log entry `Berhenti pada proses download konten` followed by `Lewati tugas karena gagal mengunduh konten`.
+5. Re-enable network connectivity before the next task starts.
+6. Confirm that the workflow proceeds to the second task, downloads the content, and uploads to Instagram successfully.
+7. Verify that the log includes the success messages for the subsequent task(s) and that the workflow completes with `Selesai`.
+
+## Expected result
+- The failed task is logged and skipped after the retry attempts.
+- Later tasks in the same run continue processing normally.


### PR DESCRIPTION
## Summary
- skip individual autopost tasks when download or Instagram upload retries exhaust so later tasks can continue
- log the skipped task context so operators know which step failed
- document manual QA steps for verifying that the workflow continues after a failure

## Testing
- ./gradlew test *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68e304936be483279649edd82d47d53c