### PR TITLE
Allow RuntimeTypeAdapterFactory to deserialize subtypes without discriminators

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     // Align with the version pulled in by the Android Gradle plugin to avoid
     // dependency resolution conflicts during the build.
     compileOnly("com.google.errorprone:error_prone_annotations:2.15.0")
-    
 
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/app/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
@@ -274,6 +274,13 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         }
 
         if (labelJsonElement == null) {
+          if (!baseType.equals(rawType)) {
+            @SuppressWarnings("unchecked") // registration requires that subtype extends T
+            TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(rawType);
+            if (delegate != null) {
+              return delegate.fromJsonTree(jsonElement);
+            }
+          }
           throw new JsonParseException(
               "cannot deserialize "
                   + baseType

--- a/app/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
+++ b/app/src/test/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactoryTest.java
@@ -1,0 +1,31 @@
+package com.google.gson.typeadapters;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Test;
+
+public final class RuntimeTypeAdapterFactoryTest {
+  private abstract static class Shape {
+    int x;
+    int y;
+  }
+
+  private static final class Circle extends Shape {
+    int radius;
+  }
+
+  @Test
+  public void recognizeSubtypesDeserializesSubtypeWithoutTypeField() {
+    RuntimeTypeAdapterFactory<Shape> factory =
+        RuntimeTypeAdapterFactory.of(Shape.class)
+            .registerSubtype(Circle.class, "Circle")
+            .recognizeSubtypes();
+
+    Gson gson = new GsonBuilder().registerTypeAdapterFactory(factory).create();
+
+    Circle circle = gson.fromJson("{\"radius\":4}", Circle.class);
+    assertEquals(4, circle.radius);
+  }
+}


### PR DESCRIPTION
## Summary
- fallback to a registered subtype delegate when the discriminator is missing and the target type is a registered subtype
- add a unit test covering recognizeSubtypes() deserialization without a type field
- include JUnit in the test classpath for the new unit test

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3930cc16c8327be668228458e32a4