### PR TITLE
Ensure Gradle uses Java 17 toolchain

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,13 +54,17 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
+}
+
+kotlin {
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,5 +14,9 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "CiceroReposter"
 include(":app")


### PR DESCRIPTION
## Summary
- update the Android module to target Java 17 bytecode and Kotlin JVM 17
- configure the Kotlin Gradle plugin to use the Java 17 toolchain
- enable the Foojay toolchain resolver so required JDKs are provisioned automatically

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ba23b6e8832798f4f62e86fe74aa