### PR TITLE
Add local CanIgnoreReturnValue annotation stub

### DIFF
--- a/app/src/main/java/com/google/errorprone/annotations/CanIgnoreReturnValue.java
+++ b/app/src/main/java/com/google/errorprone/annotations/CanIgnoreReturnValue.java
@@ -1,0 +1,17 @@
+package com.google.errorprone.annotations;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that it is acceptable to ignore the return value of an annotated method or constructor.
+ */
+@Documented
+@Target({METHOD, CONSTRUCTOR})
+@Retention(CLASS)
+public @interface CanIgnoreReturnValue {}


### PR DESCRIPTION
## Summary
- add a local definition of `com.google.errorprone.annotations.CanIgnoreReturnValue` so existing code can compile without the Error Prone dependency

## Testing
- ./gradlew app:compileDebugJavaWithJavac *(fails: Android SDK not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bd7b28c08327bd6deb127aeee79d