### PR TITLE
Avoid experimental continue in inline lambda

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/AutopostFragment.kt
@@ -940,7 +940,8 @@ class AutopostFragment : Fragment() {
             appendLog("Memproses tugas ${'$'}{post.taskNumber} (${ '$'}{post.id })")
             appendLog("Memeriksa download…")
             delay(5000)
-            val file = retryAction("download konten") { downloadIfNeeded(post) } ?: run {
+            val file = retryAction("download konten") { downloadIfNeeded(post) }
+            if (file == null) {
                 appendLog("Lewati tugas karena gagal mengunduh konten")
                 continue
             }
@@ -948,7 +949,8 @@ class AutopostFragment : Fragment() {
                 downloadCarouselImagesIfNeeded(post)
             }
             delay(5000)
-            val igLink = retryAction("upload Instagram") { uploadToInstagram(post, file) } ?: run {
+            val igLink = retryAction("upload Instagram") { uploadToInstagram(post, file) }
+            if (igLink == null) {
                 appendLog("Lewati tugas karena gagal mengunggah ke Instagram")
                 continue
             }


### PR DESCRIPTION
## Summary
- refactor the autopost workflow to avoid using continue inside inline lambdas
- keep control-flow while preventing the experimental compiler warning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c09c02708327bf9597a8ae897965