### PR TITLE
Fix missing coroutine import in DashboardFragment

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -22,9 +22,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray


### PR DESCRIPTION
## Summary
- add the missing kotlinx.coroutines.isActive import so the coroutines compile
- keep coroutine imports ordered consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c3503ee88327acbca2d5b2435e83