### PR TITLE
Secure authentication data with EncryptedSharedPreferences

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardActivity.kt
@@ -72,7 +72,7 @@ class DashboardActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_logout -> {
-                val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+                val prefs = SecurePreferences.getAuthPrefs(this)
                 prefs.edit().clear().apply()
                 startActivity(Intent(this, MainActivity::class.java))
                 finish()

--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -586,7 +586,7 @@ open class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         val today = java.time.LocalDate.now()
         val day = today.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale))
         val dateStr = today.format(java.time.format.DateTimeFormatter.ofPattern("dd MMMM yyyy", locale))
-        val prefsAuth = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val prefsAuth = SecurePreferences.getAuthPrefs(requireContext())
         val rank = prefsAuth.getString("rank", "") ?: ""
         val name = prefsAuth.getString("name", "") ?: ""
         val satfung = prefsAuth.getString("satfung", "") ?: ""

--- a/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
@@ -26,7 +26,7 @@ class LoginActivity : AppCompatActivity() {
         supportActionBar?.hide()
         setContentView(R.layout.activity_login)
 
-        val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val authPrefs = SecurePreferences.getAuthPrefs(this)
         val savedToken = authPrefs.getString("token", null)
         val savedUser = authPrefs.getString("userId", null)
         if (!savedToken.isNullOrBlank() && !savedUser.isNullOrBlank()) {
@@ -41,11 +41,12 @@ class LoginActivity : AppCompatActivity() {
 
         val loginPrefs = getSharedPreferences("login", MODE_PRIVATE)
         val savedNrp = loginPrefs.getString("nrp", "")
-        val savedPass = loginPrefs.getString("password", "")
-        if (!savedNrp.isNullOrBlank() && !savedPass.isNullOrBlank()) {
+        if (!savedNrp.isNullOrBlank()) {
             nrpInput.setText(savedNrp)
-            passwordInput.setText(savedPass)
             saveLoginBox.isChecked = true
+        }
+        if (loginPrefs.contains("password")) {
+            loginPrefs.edit { remove("password") }
         }
 
         showPasswordBox.setOnCheckedChangeListener { _, checked ->
@@ -113,7 +114,7 @@ class LoginActivity : AppCompatActivity() {
                             val token = obj.optString("token", "")
                             val user = obj.optJSONObject("user")
                             val userId = user?.optString("user_id", nrp) ?: nrp
-                            val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+                            val prefs = SecurePreferences.getAuthPrefs(this@LoginActivity)
                             prefs.edit {
                                 putString("token", token)
                                 putString("userId", userId)
@@ -122,7 +123,7 @@ class LoginActivity : AppCompatActivity() {
                             if (saveLogin) {
                                 loginPrefs.edit {
                                     putString("nrp", nrp)
-                                    putString("password", phone)
+                                    remove("password")
                                 }
                             } else {
                                 loginPrefs.edit { clear() }

--- a/app/src/main/java/com/cicero/repostapp/MainActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/MainActivity.kt
@@ -24,7 +24,7 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.setLogo(R.mipmap.ic_launcher_foreground)
         supportActionBar?.setDisplayUseLogoEnabled(true)
 
-        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val prefs = SecurePreferences.getAuthPrefs(this)
         val token = prefs.getString("token", null)
         val userId = prefs.getString("userId", null)
         if (!token.isNullOrBlank() && !userId.isNullOrBlank()) {

--- a/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/PremiumRegistrationActivity.kt
@@ -23,7 +23,7 @@ class PremiumRegistrationActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_premium_registration)
 
-        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val prefs = SecurePreferences.getAuthPrefs(this)
         val token = prefs.getString("token", "") ?: ""
 
         val activeStatusView = findViewById<TextView>(R.id.text_active_status)
@@ -50,9 +50,6 @@ class PremiumRegistrationActivity : AppCompatActivity() {
         val nama = findViewById<EditText>(R.id.input_nama_rekening)
         val nomor = findViewById<EditText>(R.id.input_nomor_rekening)
         val phone = findViewById<EditText>(R.id.input_phone)
-        val loginPrefs = getSharedPreferences("login", MODE_PRIVATE)
-        val savedPhone = loginPrefs.getString("password", "")
-        savedPhone?.takeIf { it.isNotBlank() }?.let { phone.setText(it) }
         val button = findViewById<Button>(R.id.button_submit)
         val cancelButton = findViewById<Button>(R.id.button_cancel)
 
@@ -63,7 +60,7 @@ class PremiumRegistrationActivity : AppCompatActivity() {
         cancelButton.setOnClickListener { finish() }
 
         button.setOnClickListener {
-            val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+            val prefs = SecurePreferences.getAuthPrefs(this)
             val token = prefs.getString("token", "") ?: ""
             if (token.isBlank()) {
                 Toast.makeText(this, "Anda belum login", Toast.LENGTH_SHORT).show()
@@ -97,7 +94,7 @@ class PremiumRegistrationActivity : AppCompatActivity() {
                     if (success) {
                         Toast.makeText(this@PremiumRegistrationActivity, "Pendaftaran tersimpan", Toast.LENGTH_SHORT).show()
 
-                        val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
+                        val authPrefs = SecurePreferences.getAuthPrefs(this@PremiumRegistrationActivity)
                         val rank = authPrefs.getString("rank", "") ?: ""
                         val nameUser = authPrefs.getString("name", "") ?: ""
                         val nrpUser = authPrefs.getString("userId", usernameVal) ?: usernameVal

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -87,7 +87,7 @@ class ReportActivity : AppCompatActivity() {
         supportActionBar?.setLogo(R.mipmap.ic_launcher_round)
         supportActionBar?.setDisplayUseLogoEnabled(true)
 
-        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val prefs = SecurePreferences.getAuthPrefs(this)
         token = prefs.getString("token", "") ?: ""
         userId = prefs.getString("userId", "") ?: ""
 
@@ -415,7 +415,7 @@ class ReportActivity : AppCompatActivity() {
         val today = java.time.LocalDate.now()
         val day = today.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale))
         val dateStr = today.format(java.time.format.DateTimeFormatter.ofPattern("dd MMMM yyyy", locale))
-        val prefsAuth = getSharedPreferences("auth", MODE_PRIVATE)
+        val prefsAuth = SecurePreferences.getAuthPrefs(this)
         val rank = prefsAuth.getString("rank", "") ?: ""
         val name = prefsAuth.getString("name", "") ?: ""
         val satfung = prefsAuth.getString("satfung", "") ?: ""

--- a/app/src/main/java/com/cicero/repostapp/SecurePreferences.kt
+++ b/app/src/main/java/com/cicero/repostapp/SecurePreferences.kt
@@ -1,0 +1,60 @@
+package com.cicero.repostapp
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+object SecurePreferences {
+    private const val AUTH_PREF_NAME = "auth_secure"
+    private const val LEGACY_AUTH_PREF_NAME = "auth"
+
+    fun getAuthPrefs(context: Context): SharedPreferences {
+        val appContext = context.applicationContext
+        val masterKey = MasterKey.Builder(appContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        val encryptedPrefs = EncryptedSharedPreferences.create(
+            appContext,
+            AUTH_PREF_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+
+        migrateLegacyAuthPrefs(appContext, encryptedPrefs)
+        return encryptedPrefs
+    }
+
+    private fun migrateLegacyAuthPrefs(
+        context: Context,
+        encryptedPrefs: SharedPreferences
+    ) {
+        val legacyPrefs = context.getSharedPreferences(LEGACY_AUTH_PREF_NAME, Context.MODE_PRIVATE)
+        if (legacyPrefs.all.isEmpty()) {
+            return
+        }
+
+        val legacyToken = legacyPrefs.getString("token", null)
+        val legacyUserId = legacyPrefs.getString("userId", null)
+
+        if (!legacyToken.isNullOrBlank() || !legacyUserId.isNullOrBlank()) {
+            encryptedPrefs.edit {
+                if (!legacyToken.isNullOrBlank()) {
+                    putString("token", legacyToken)
+                } else {
+                    remove("token")
+                }
+                if (!legacyUserId.isNullOrBlank()) {
+                    putString("userId", legacyUserId)
+                } else {
+                    remove("userId")
+                }
+            }
+        }
+
+        legacyPrefs.edit { clear() }
+    }
+}

--- a/app/src/main/java/com/cicero/repostapp/SpecialTaskFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/SpecialTaskFragment.kt
@@ -513,7 +513,7 @@ class SpecialTaskFragment : Fragment(R.layout.fragment_special_task) {
         val today = java.time.LocalDate.now()
         val day = today.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale))
         val dateStr = today.format(java.time.format.DateTimeFormatter.ofPattern("dd MMMM yyyy", locale))
-        val prefsAuth = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val prefsAuth = SecurePreferences.getAuthPrefs(requireContext())
         val rank = prefsAuth.getString("rank", "") ?: ""
         val name = prefsAuth.getString("name", "") ?: ""
         val satfung = prefsAuth.getString("satfung", "") ?: ""

--- a/app/src/main/java/com/cicero/repostapp/SplashActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/SplashActivity.kt
@@ -17,7 +17,7 @@ class SplashActivity : AppCompatActivity() {
         supportActionBar?.hide()
         setContentView(R.layout.activity_splash)
 
-        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val prefs = SecurePreferences.getAuthPrefs(this)
         val token = prefs.getString("token", null)
         val userId = prefs.getString("userId", null)
         if (!token.isNullOrBlank() && !userId.isNullOrBlank()) {

--- a/app/src/main/java/com/cicero/repostapp/SubscriptionConfirmActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/SubscriptionConfirmActivity.kt
@@ -25,7 +25,7 @@ class SubscriptionConfirmActivity : AppCompatActivity() {
         cancelButton.setOnClickListener { finish() }
 
         confirmButton.setOnClickListener {
-            val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+            val prefs = SecurePreferences.getAuthPrefs(this)
             val token = prefs.getString("token", "") ?: ""
             val userId = intent.getStringExtra("userId") ?: ""
             if (token.isBlank() || userId.isBlank()) {

--- a/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/UserProfileFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
-import android.content.Context
 import android.widget.ImageView
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
@@ -66,7 +65,7 @@ class UserProfileFragment : Fragment(R.layout.activity_profile) {
                             val satfung = data?.optString("divisi") ?: ""
                             val nrp = data?.optString("user_id") ?: userId
 
-                            val authPrefs = requireContext().getSharedPreferences("auth", Context.MODE_PRIVATE)
+                            val authPrefs = SecurePreferences.getAuthPrefs(requireContext())
                             authPrefs.edit()
                                 .putString("rank", rank)
                                 .putString("name", name)


### PR DESCRIPTION
## Summary
- introduce a SecurePreferences helper that wraps EncryptedSharedPreferences and migrates legacy auth data
- refactor the login flow to avoid persisting passwords while storing tokens and user identifiers in encrypted preferences
- update activities and fragments to consume the encrypted auth storage for logout, reporting, and subscription flows

## Testing
- ./gradlew :app:compileDebugSources *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ce8ec48c8327a42c724ecd185f0a