### PR TITLE
Add inline validation for login form inputs

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
@@ -10,7 +10,9 @@ import android.widget.Toast
 import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
+import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -39,6 +41,8 @@ class LoginActivity : AppCompatActivity() {
         }
         val nrpInput = findViewById<EditText>(R.id.input_nrp)
         val passwordInput = findViewById<EditText>(R.id.input_password)
+        val nrpLayout = findViewById<TextInputLayout>(R.id.layout_nrp)
+        val passwordLayout = findViewById<TextInputLayout>(R.id.layout_password)
         val showPasswordBox = findViewById<CheckBox>(R.id.checkbox_show_password)
         val saveLoginBox = findViewById<CheckBox>(R.id.checkbox_save_login)
         val loginButton = findViewById<Button>(R.id.button_login)
@@ -63,15 +67,43 @@ class LoginActivity : AppCompatActivity() {
             passwordInput.setSelection(passwordInput.text?.length ?: 0)
         }
 
+        nrpInput.addTextChangedListener { text ->
+            if (!text.isNullOrBlank()) {
+                nrpLayout.error = null
+            }
+        }
+
+        passwordInput.addTextChangedListener { text ->
+            if (!text.isNullOrBlank()) {
+                passwordLayout.error = null
+            }
+        }
+
         loginButton.setOnClickListener {
             val nrp = nrpInput.text.toString().trim()
             val phone = passwordInput.text.toString().trim()
             val save = saveLoginBox.isChecked
-            if (nrp.isBlank() || phone.isBlank()) {
-                Toast.makeText(this, "NRP dan password wajib diisi", Toast.LENGTH_SHORT).show()
+
+            var hasError = false
+            if (nrp.isBlank()) {
+                nrpLayout.error = getString(R.string.error_nrp_required)
+                hasError = true
             } else {
-                login(nrp, phone, save)
+                nrpLayout.error = null
             }
+
+            if (phone.isBlank()) {
+                passwordLayout.error = getString(R.string.error_password_required)
+                hasError = true
+            } else {
+                passwordLayout.error = null
+            }
+
+            if (hasError) {
+                return@setOnClickListener
+            }
+
+            login(nrp, phone, save)
         }
 
         registerButton.setOnClickListener {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -50,6 +50,7 @@
                     android:padding="24dp">
 
                     <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layout_nrp"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="@string/nrp"
@@ -63,6 +64,7 @@
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layout_password"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="@string/password"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="register">Registrasi</string>
     <string name="save_login">Save Login</string>
     <string name="show_password">Show Password</string>
+    <string name="error_nrp_required">NRP wajib diisi</string>
+    <string name="error_password_required">Password wajib diisi</string>
     <string name="bagikan_ulang_konten_resmi_lebih_mudah">Bagikan Ulang Konten Resmi Lebih Mudah</string>
     <string name="landing_subtitle">Unduh, Repost dan Kirim Laporan Link dalam Satu Aplikasi.</string>
     <string name="feature_authentication">Authentikasi - Registrasi via WA Bot</string>


### PR DESCRIPTION
## Summary
- add identifiers to the login input layouts so they can surface validation state
- display inline validation errors for empty NRP and password fields and clear them as the user types
- provide localized strings for the new validation messages

## Testing
- ./gradlew lint *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d20bd2708327a4ab0d9c52b2bd51