### PR TITLE
Send phone as password field in login

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/LoginActivity.kt
@@ -119,6 +119,7 @@ class LoginActivity : AppCompatActivity() {
             val json = JSONObject().apply {
                 put("nrp", nrp)
                 put("whatsapp", phone)
+                put("password", phone)
             }
             val body = json.toString().toRequestBody("application/json".toMediaType())
             val request = Request.Builder()

--- a/docs/LOGIN_FLOW.md
+++ b/docs/LOGIN_FLOW.md
@@ -19,6 +19,7 @@ This document describes how the application handles user authentication when a l
 
 - **LoginActivity** contains a form for NRP and phone number (as password).
   - Input is validated locally (non-empty fields) and a request is sent over HTTPS to `/api/auth/user-login`.
+  - Nomor WhatsApp dikirim sebagai nilai untuk field `whatsapp` dan `password` di request body JSON.
   - On success, the JWT token and user ID are stored securely and the dashboard is opened.
   - When the activity starts it also validates any stored token so returning users skip the form entirely.
 - Errors are shown as toast messages, such as "NRP dan password wajib diisi" or "Gagal terhubung ke server".


### PR DESCRIPTION
## Summary
- include the phone number in the login payload as both whatsapp and password
- document that the WhatsApp number populates the two fields in the JSON body

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d9d3b5e48327bf7ccad137919321