### PR TITLE
Filter link report lookups by shortcode and user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ several activities:
   and host a bottom navigation bar
 - `ReportActivity` for viewing repost links
 
+The Express development backend that ships with the project exposes
+`/api/link-reports` and `/api/link-reports-khusus`. Both endpoints accept optional
+`shortcode` and `user_id` query parameters to return at most one matching record,
+which allows the Android client to load any existing submission without
+retrieving the full dataset.
+
 The project uses Gradle Kotlin DSL. To build the project you would typically run:
 
 ```bash


### PR DESCRIPTION
## Summary
- add shortcode and user_id query filtering to the link report endpoints so they only return the matching record
- request the filtered report from ReportActivity using HttpUrl.Builder and simplify the parsing to the first item
- document the new query parameters on the link report endpoints

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68e4e4721ecc8327be44d1e19b80eedb