### PR TITLE
Use lifecycleScope for report coroutines

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -10,8 +10,8 @@ import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.widget.ImageView
 import android.content.SharedPreferences
+import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -214,7 +214,7 @@ class ReportActivity : AppCompatActivity() {
     }
 
     private fun loadExistingReport() {
-        CoroutineScope(Dispatchers.IO).launch {
+        lifecycleScope.launch(Dispatchers.IO) {
             val obj = getExistingReport(shortcode!!)
             if (obj != null) {
                 withContext(Dispatchers.Main) {
@@ -390,7 +390,7 @@ class ReportActivity : AppCompatActivity() {
             return
         }
 
-        CoroutineScope(Dispatchers.IO).launch {
+        lifecycleScope.launch(Dispatchers.IO) {
             val remoteDuplicates = fetchExistingLinks(
                 links.values.mapNotNull { it }
             )


### PR DESCRIPTION
## Summary
- replace manual CoroutineScope usage in ReportActivity with lifecycleScope bound launches
- ensure existing background work continues to update the UI on the main dispatcher
- remove unused CoroutineScope import now that lifecycleScope is used

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e697c0588327b25122a6d71688d7