### PR TITLE
Limit link reports duplicate queries to summary payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ The Express development backend that ships with the project exposes
 `/api/link-reports` and `/api/link-reports-khusus`. Both endpoints accept optional
 `shortcode` and `user_id` query parameters to return at most one matching record,
 which allows the Android client to load any existing submission without
-retrieving the full dataset.
+retrieving the full dataset. When either endpoint receives one or more
+`links[]` query parameters it now returns a compact duplicate summary instead of
+the entire report list:
+
+```http
+GET /api/link-reports?links[]=https://instagram.com/p/example
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "duplicates": ["https://instagram.com/p/example"],
+  "count": 1
+}
+```
+
+Clients should rely on the `duplicates` array and avoid falling back to
+inspecting a `data` payload for these filtered requests.
 
 The project uses Gradle Kotlin DSL. To build the project you would typically run:
 

--- a/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
+++ b/app/src/main/java/com/cicero/repostapp/ReportActivity.kt
@@ -297,7 +297,6 @@ class ReportActivity : AppCompatActivity() {
             if (trimmed.isBlank()) null else trimmed
         }
         if (sanitized.isEmpty()) return emptySet()
-        val requestedNormalized = sanitized.map { it.lowercase(java.util.Locale.ROOT) }.toSet()
         val baseUrl = "${BuildConfig.API_BASE_URL}/api/link-reports${if (isSpecial) "-khusus" else ""}"
         val httpUrl = baseUrl.toHttpUrlOrNull()?.newBuilder()?.apply {
             sanitized.forEach { addQueryParameter("links[]", it) }
@@ -314,32 +313,10 @@ class ReportActivity : AppCompatActivity() {
                     JSONObject(body ?: "{}").optJSONArray("duplicates") ?: JSONArray()
                 } catch (_: Exception) { JSONArray() }
                 val duplicates = mutableSetOf<String>()
-                if (duplicatesJson.length() > 0) {
-                    for (i in 0 until duplicatesJson.length()) {
-                        val link = duplicatesJson.optString(i)
-                        if (!link.isNullOrBlank()) {
-                            duplicates.add(link.trim().lowercase(java.util.Locale.ROOT))
-                        }
-                    }
-                } else {
-                    val arr = try {
-                        JSONObject(body ?: "{}").optJSONArray("data") ?: JSONArray()
-                    } catch (_: Exception) { JSONArray() }
-                    for (i in 0 until arr.length()) {
-                        val obj = arr.optJSONObject(i) ?: continue
-                        val remoteLinks = listOf(
-                            obj.optString("instagram_link"),
-                            obj.optString("facebook_link"),
-                            obj.optString("twitter_link"),
-                            obj.optString("tiktok_link"),
-                            obj.optString("youtube_link")
-                        )
-                        remoteLinks.forEach { remoteLink ->
-                            val normalized = remoteLink.trim().lowercase(java.util.Locale.ROOT)
-                            if (normalized.isNotBlank() && normalized in requestedNormalized) {
-                                duplicates.add(normalized)
-                            }
-                        }
+                for (i in 0 until duplicatesJson.length()) {
+                    val link = duplicatesJson.optString(i)
+                    if (!link.isNullOrBlank()) {
+                        duplicates.add(link.trim().lowercase(java.util.Locale.ROOT))
                     }
                 }
                 duplicates

--- a/server.js
+++ b/server.js
@@ -71,7 +71,7 @@ const handleGetLinkReports = (isSpecial) => (req, res) => {
 
   if (requestedLinks.length) {
     const duplicates = collectDuplicates(collection, requestedLinks);
-    return res.json({ data: filteredData, duplicates });
+    return res.json({ duplicates, count: duplicates.length });
   }
   res.json({ data: filteredData });
 };


### PR DESCRIPTION
## Summary
- ensure the link report endpoints return only duplicate summaries when filtering by links[]
- simplify the Android duplicate fetcher to rely on the filtered response
- document the new lightweight API contract so other clients avoid large payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ea9f0898832784f5e03be2cdc837