### PR TITLE
Exclude duplicate error prone annotations from release build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,10 @@ kotlin {
     jvmToolchain(17)
 }
 
+configurations.all {
+    exclude(group = "com.google.errorprone", module = "error_prone_annotations")
+}
+
 dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.appcompat:appcompat:1.6.1")


### PR DESCRIPTION
## Summary
- exclude the `com.google.errorprone:error_prone_annotations` artifact from all configurations to prevent duplicate class packaging errors during release builds

## Testing
- `./gradlew app:assembleRelease` *(fails: requires local Android SDK configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e5059c76308327b96a74e5981e8461