### PR TITLE
Handle share chooser fallback in DashboardFragment

### DIFF
--- a/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
+++ b/app/src/main/java/com/cicero/repostapp/DashboardFragment.kt
@@ -453,14 +453,17 @@ open class DashboardFragment : Fragment(R.layout.fragment_dashboard) {
         if (!post.caption.isNullOrBlank()) {
             intent.putExtra(Intent.EXTRA_TEXT, post.caption)
         }
-        if (packageName != null) {
-            intent.setPackage(packageName)
-        }
         val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         clipboard.setPrimaryClip(ClipData.newPlainText("caption", post.caption ?: ""))
-        try {
-            startActivity(intent)
-        } catch (_: Exception) {
+        if (packageName != null) {
+            intent.setPackage(packageName)
+            try {
+                startActivity(intent)
+            } catch (_: Exception) {
+                intent.setPackage(null)
+                startActivity(Intent.createChooser(intent, "Share via"))
+            }
+        } else {
             startActivity(Intent.createChooser(intent, "Share via"))
         }
     }


### PR DESCRIPTION
## Summary
- show the system share chooser when no specific package is requested
- keep targeted sharing but fall back to the chooser if the target app is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a537e8a48327ba25cf835858d374